### PR TITLE
docs: update docs links from cookbook to templates

### DIFF
--- a/docs/guides/creating-agents.mdx
+++ b/docs/guides/creating-agents.mdx
@@ -197,7 +197,7 @@ This is useful for:
 
 ## Examples
 
-For a comprehensive collection of agent examples, including data analysis, code review, API integration, and more, visit the [AgentUse Cookbook](https://github.com/agentuse/agentuse/tree/main/cookbook/agents).
+For a comprehensive collection of agent examples, including data analysis, code review, API integration, and more, visit the [AgentUse Templates](https://github.com/agentuse/agentuse/tree/main/templates/agents).
 
 ## Next Steps
 
@@ -208,7 +208,7 @@ For a comprehensive collection of agent examples, including data analysis, code 
   <Card title="Agent Design Patterns" icon="diagram-project" href="/guides/agent-design-patterns">
     Best practices and patterns for building agents
   </Card>
-  <Card title="Examples" icon="code" href="https://github.com/agentuse/agentuse/tree/main/cookbook/agents">
+  <Card title="Examples" icon="code" href="https://github.com/agentuse/agentuse/tree/main/templates/agents">
     See more agent examples
   </Card>
 </CardGroup>

--- a/docs/guides/remote-agents.mdx
+++ b/docs/guides/remote-agents.mdx
@@ -266,7 +266,7 @@ agentuse run https://raw.githubusercontent.com/team/agents/main/deployment/pre-d
   <Card title="Sub-Agents" icon="layer-group" href="/guides/subagents">
     Compose agents together
   </Card>
-  <Card title="Examples" icon="code" href="https://github.com/agentuse/agentuse/tree/main/cookbook/agents">
+  <Card title="Examples" icon="code" href="https://github.com/agentuse/agentuse/tree/main/templates/agents">
     See remote agent examples
   </Card>
 </CardGroup>

--- a/docs/guides/subagents.mdx
+++ b/docs/guides/subagents.mdx
@@ -377,7 +377,7 @@ agentuse run ./agents/researcher.agentuse "test query"
   <Card title="Remote Agents" icon="globe" href="/guides/remote-agents">
     Learn about remote agent execution
   </Card>
-  <Card title="Examples" icon="code" href="https://github.com/agentuse/agentuse/tree/main/cookbook/agents">
+  <Card title="Examples" icon="code" href="https://github.com/agentuse/agentuse/tree/main/templates/agents">
     See sub-agent examples
   </Card>
 </CardGroup>

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -29,7 +29,7 @@ description: Build production AI agents with just markdown files
   <Card
     title="Examples"
     icon="code"
-    href="https://github.com/agentuse/agentuse/tree/main/cookbook/agents"
+    href="https://github.com/agentuse/agentuse/tree/main/templates/agents"
   >
     Browse ready-to-use agent examples
   </Card>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -205,7 +205,7 @@ export OPENAI_API_KEY_PERSONAL="sk-proj-..."
   <Card title="Creating Agents" icon="file-pen" href="/guides/creating-agents">
     Learn agent syntax
   </Card>
-  <Card title="Examples" icon="lightbulb" href="https://github.com/agentuse/agentuse/tree/main/cookbook/agents">
+  <Card title="Examples" icon="lightbulb" href="https://github.com/agentuse/agentuse/tree/main/templates/agents">
     See more examples
   </Card>
 </CardGroup>

--- a/docs/reference/agent-syntax.mdx
+++ b/docs/reference/agent-syntax.mdx
@@ -423,7 +423,7 @@ Assist the user with their request using all available capabilities.
   <Card title="Environment Variables" icon="gear" href="/reference/environment-variables">
     Configure environment
   </Card>
-  <Card title="Examples" icon="code" href="https://github.com/agentuse/agentuse/tree/main/cookbook/agents">
+  <Card title="Examples" icon="code" href="https://github.com/agentuse/agentuse/tree/main/templates/agents">
     See it in action
   </Card>
 </CardGroup>


### PR DESCRIPTION
Update multiple documentation pages to point example links to the new templates location on GitHub instead of the old cookbook path.

- Replace occurrences of https://github.com/agentuse/agentuse/tree/main/cookbook/agents with https://github.com/agentuse/agentuse/tree/main/templates/agents in: docs/guides/remote-agents.mdx docs/introduction.mdx docs/guides/creating-agents.mdx docs/reference/agent-syntax.mdx docs/guides/subagents.mdx docs/quickstart.mdx

This ensures documentation references the current repository layout and directs users to the maintained templates/examples location.