### PR TITLE
feat: add Amazon Bedrock provider support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **Amazon Bedrock provider** (`bedrock:`) via `@ai-sdk/amazon-bedrock`
+  - Supports AWS SigV4 (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION`, optional `AWS_SESSION_TOKEN`) and Bearer token (`AWS_BEARER_TOKEN_BEDROCK`) authentication
+  - `parseModelConfig` preserves colons in Bedrock model IDs (e.g. `bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0`)
+  - Static model-registry validation is skipped for `bedrock:` so any AWS-supported model ID is accepted
+  - Documentation updates: model configuration guide, models reference, CLI commands, environment variables, self-hosting, agent syntax
+
 ## [0.10.0] - 2026-03-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ schedule: "0 9 * * *"
 ## Features
 
 ### 🤖 Multi-Provider Support
-Works with Anthropic (Claude), OpenAI (GPT), and OpenRouter for open source models like GLM and Minimax. Switch models with a single line change.
+Works with Anthropic (Claude), OpenAI (GPT), OpenRouter (open source models like GLM and Minimax), and Amazon Bedrock. Switch models with a single line change.
 
 ### 🌐 Webhooks & HTTP API
 Trigger agents via HTTP webhooks. Integrate with Zapier, Make, GitHub Actions, or any system that can POST. Supports streaming responses for real-time output.

--- a/docs/guides/model-configuration.mdx
+++ b/docs/guides/model-configuration.mdx
@@ -22,6 +22,10 @@ AgentUse supports multiple AI providers. You need to authenticate with at least 
     Access to 100+ models via unified API
     API key authentication
   </Card>
+  <Card title="Amazon Bedrock">
+    Claude, Llama, Mistral, Nova and more via AWS
+    AWS SigV4 or Bearer token
+  </Card>
   <Card title="Custom / Local">
     Any OpenAI-compatible endpoint: Ollama, LM Studio, vLLM, llama.cpp, etc.
   </Card>
@@ -88,6 +92,36 @@ agentuse run agent.md --model openai:gpt-5.2:OPENAI_API_KEY_PERSONAL
   .env.*.local
   ```
 </Warning>
+
+## Amazon Bedrock
+
+Bedrock authenticates with standard AWS credentials rather than `agentuse provider login`.
+
+```bash
+export AWS_REGION=us-east-1
+export AWS_ACCESS_KEY_ID="AKIA..."
+export AWS_SECRET_ACCESS_KEY="..."
+# Optional, for STS / assumed-role temporary credentials
+export AWS_SESSION_TOKEN="..."
+```
+
+Alternatively, use a Bedrock API key (Bearer token):
+
+```bash
+export AWS_REGION=us-east-1
+export AWS_BEARER_TOKEN_BEDROCK="..."
+```
+
+Use the full Bedrock model ID (which contains colons) as-is:
+
+```bash
+agentuse run agent.agentuse -m bedrock:us.anthropic.claude-sonnet-4-5-20250929-v1:0
+agentuse run agent.agentuse -m bedrock:meta.llama3-70b-instruct-v1:0
+```
+
+<Note>
+  Your IAM user/role needs `AmazonBedrockFullAccess` (or an equivalent custom policy) and you must have requested access to the foundation model in the AWS console. The `bedrock:` prefix bypasses the static model registry, so any Bedrock model ID is accepted.
+</Note>
 
 ## Custom Providers (Local LLMs)
 

--- a/docs/guides/model-configuration.mdx
+++ b/docs/guides/model-configuration.mdx
@@ -95,7 +95,9 @@ agentuse run agent.md --model openai:gpt-5.2:OPENAI_API_KEY_PERSONAL
 
 ## Amazon Bedrock
 
-Bedrock authenticates with standard AWS credentials rather than `agentuse provider login`.
+Bedrock authenticates with standard AWS credentials rather than `agentuse provider login`. Three modes are supported (in priority order):
+
+**1. Static IAM access keys (SigV4)**
 
 ```bash
 export AWS_REGION=us-east-1
@@ -105,22 +107,32 @@ export AWS_SECRET_ACCESS_KEY="..."
 export AWS_SESSION_TOKEN="..."
 ```
 
-Alternatively, use a Bedrock API key (Bearer token):
+**2. Bedrock API key (Bearer token)**
 
 ```bash
 export AWS_REGION=us-east-1
 export AWS_BEARER_TOKEN_BEDROCK="..."
 ```
 
-Use the full Bedrock model ID (which contains colons) as-is:
+**3. AWS SDK credential provider chain** — used automatically when neither of the above is set. Resolves `AWS_PROFILE`, `~/.aws/credentials`, SSO cache, EC2/ECS/EKS instance roles, etc.
+
+```bash
+# Refresh SSO / assume-role credentials for your profile, then run:
+export AWS_REGION=eu-west-1
+export AWS_PROFILE=my-bedrock-profile
+agentuse run agent.agentuse -m bedrock:us.anthropic.claude-sonnet-4-5-20250929-v1:0
+```
+
+Use the full Bedrock model ID (which contains colons) as-is, or an inference profile ARN:
 
 ```bash
 agentuse run agent.agentuse -m bedrock:us.anthropic.claude-sonnet-4-5-20250929-v1:0
 agentuse run agent.agentuse -m bedrock:meta.llama3-70b-instruct-v1:0
+agentuse run agent.agentuse -m bedrock:arn:aws:bedrock:eu-west-1:123456789012:application-inference-profile/abcd1234
 ```
 
 <Note>
-  Your IAM user/role needs `AmazonBedrockFullAccess` (or an equivalent custom policy) and you must have requested access to the foundation model in the AWS console. The `bedrock:` prefix bypasses the static model registry, so any Bedrock model ID is accepted.
+  Your IAM user/role needs `AmazonBedrockFullAccess` (or an equivalent custom policy) and you must have requested access to the foundation model in the AWS console. The `bedrock:` prefix bypasses the static model registry, so any Bedrock model ID or inference-profile ARN is accepted.
 </Note>
 
 ## Custom Providers (Local LLMs)

--- a/docs/guides/self-hosting.mdx
+++ b/docs/guides/self-hosting.mdx
@@ -77,6 +77,9 @@ docker exec -it agentuse-dev agentuse run my-agent.agentuse
 | `CLAUDE_CODE_OAUTH_TOKEN` | Long-lived OAuth token from `claude setup-token` (valid 1 year) |
 | `OPENAI_API_KEY` | OpenAI API key |
 | `OPENROUTER_API_KEY` | OpenRouter API key |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` | Amazon Bedrock (SigV4 auth) |
+| `AWS_SESSION_TOKEN` | Optional Bedrock session token (temporary credentials) |
+| `AWS_BEARER_TOKEN_BEDROCK` | Amazon Bedrock API key (Bearer auth, alternative to SigV4) |
 
 <Note>
   At least one AI provider authentication is required. For Anthropic, use either `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -72,7 +72,7 @@ AgentUse creates autonomous agents that work without you. Define agents in markd
     Run agents via cron jobs, CI/CD pipelines, and serverless functions. Sub-second startup times.
   </Step>
   <Step title="Multi-Provider Support">
-    Works with Anthropic Claude (including OAuth), OpenAI GPT, and OpenRouter with flexible API key management.
+    Works with Anthropic Claude (including OAuth), OpenAI GPT, OpenRouter, and Amazon Bedrock with flexible API key management.
   </Step>
   <Step title="MCP Integration">
     Connect to any Model Context Protocol server for database, filesystem, and API access.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -31,10 +31,11 @@ AgentUse supports multiple AI providers with the format `provider:model-name`. E
 anthropic:claude-sonnet-4-6
 openai:gpt-5.2
 openrouter:minimax/minimax-m2.1
+bedrock:us.anthropic.claude-sonnet-4-5-20250929-v1:0
 ```
 
 <Tip>
-  Any model available from Anthropic, OpenAI, or OpenRouter can be used. You can also specify custom API keys: `anthropic:claude-sonnet-4-6:CUSTOM_API_KEY`
+  Any model available from Anthropic, OpenAI, OpenRouter, or Amazon Bedrock can be used. You can also specify custom API keys: `anthropic:claude-sonnet-4-6:CUSTOM_API_KEY`
 </Tip>
 
 ## Your First Agent

--- a/docs/reference/agent-syntax.mdx
+++ b/docs/reference/agent-syntax.mdx
@@ -34,11 +34,13 @@ Additional instructions or context.
   - `anthropic` - Anthropic Claude models
   - `openai` - OpenAI GPT models  
   - `openrouter` - OpenRouter models
+  - `bedrock` - Amazon Bedrock (Claude, Llama, Mistral, Nova, etc.)
   
   ```yaml
   model: anthropic:claude-sonnet-4-6
   model: openai:gpt-5-mini
   model: openrouter:z-ai/glm-4.7
+  model: bedrock:us.anthropic.claude-sonnet-4-5-20250929-v1:0
   ```
   
   You can also specify a custom environment variable suffix:

--- a/docs/reference/cli-commands.mdx
+++ b/docs/reference/cli-commands.mdx
@@ -95,7 +95,7 @@ provider:model[:env]
 ```
 
 Where:
-- `provider`: A built-in provider (`anthropic`, `openai`, `openrouter`) or a custom provider name
+- `provider`: A built-in provider (`anthropic`, `openai`, `openrouter`, `bedrock`) or a custom provider name
 - `model`: The specific model name (e.g., `claude-sonnet-4-6`, `gpt-5.2`, `glm-4.7-flash:q4_K_M`)
 - `env`: Optional environment suffix for API keys (e.g., `dev`, `prod`, or full env var name) — built-in providers only
 
@@ -430,6 +430,10 @@ Manage providers and authentication credentials. (`auth` still works as a hidden
 ```bash
 agentuse provider login [provider]   # anthropic, openai, openrouter
 ```
+
+<Note>
+  Amazon Bedrock authenticates via standard AWS environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, optional `AWS_SESSION_TOKEN`) or `AWS_BEARER_TOKEN_BEDROCK`. There is no `provider login bedrock` command.
+</Note>
 
 ### provider add
 

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -52,6 +52,46 @@ These environment variables are required for authenticating with AI providers.
   ```
 </ParamField>
 
+<ParamField path="AWS_ACCESS_KEY_ID" type="string">
+  AWS access key ID for Amazon Bedrock authentication (SigV4). Used together with `AWS_SECRET_ACCESS_KEY` and `AWS_REGION`.
+
+  ```bash
+  export AWS_ACCESS_KEY_ID="AKIA..."
+  ```
+</ParamField>
+
+<ParamField path="AWS_SECRET_ACCESS_KEY" type="string">
+  AWS secret access key for Amazon Bedrock authentication (SigV4).
+
+  ```bash
+  export AWS_SECRET_ACCESS_KEY="..."
+  ```
+</ParamField>
+
+<ParamField path="AWS_REGION" type="string">
+  AWS region for Amazon Bedrock API calls (e.g. `us-east-1`). Falls back to `AWS_DEFAULT_REGION` if unset. Required when using Bedrock.
+
+  ```bash
+  export AWS_REGION="us-east-1"
+  ```
+</ParamField>
+
+<ParamField path="AWS_SESSION_TOKEN" type="string">
+  Optional AWS session token for temporary credentials (e.g. STS / assumed roles) when using Amazon Bedrock.
+
+  ```bash
+  export AWS_SESSION_TOKEN="..."
+  ```
+</ParamField>
+
+<ParamField path="AWS_BEARER_TOKEN_BEDROCK" type="string">
+  Bedrock API key (Bearer token). When set, used instead of AWS SigV4 authentication.
+
+  ```bash
+  export AWS_BEARER_TOKEN_BEDROCK="..."
+  ```
+</ParamField>
+
 ## Custom API Key Suffixes
 
 You can use multiple API keys by adding suffixes:

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -92,6 +92,15 @@ These environment variables are required for authenticating with AI providers.
   ```
 </ParamField>
 
+<ParamField path="AWS_PROFILE" type="string">
+  AWS named profile from `~/.aws/credentials` / `~/.aws/config`. Used when no static keys or Bearer token are set: the SDK credential provider chain resolves SSO cache, assumed roles, instance metadata, etc.
+
+  ```bash
+  export AWS_REGION=eu-west-1
+  export AWS_PROFILE=my-bedrock-profile
+  ```
+</ParamField>
+
 ## Custom API Key Suffixes
 
 You can use multiple API keys by adding suffixes:

--- a/docs/reference/models.mdx
+++ b/docs/reference/models.mdx
@@ -17,6 +17,7 @@ This page lists recommended models for AgentUse, organized by provider.
 - **Anthropic**: `anthropic:claude-sonnet-4-6` (balanced performance)
 - **OpenAI**: `openai:gpt-5.4` (latest GPT)
 - **OpenRouter**: `openrouter:z-ai/glm-4.7` (open source)
+- **Amazon Bedrock**: `bedrock:us.anthropic.claude-sonnet-4-5-20250929-v1:0`
 
 ## Recommended Models
 
@@ -67,6 +68,23 @@ This page lists recommended models for AgentUse, organized by provider.
 | `openrouter:z-ai/glm-4.5-air` | GLM 4.5 Air | 128,000 | 96,000 | Reasoning, Tools |
 | `openrouter:z-ai/glm-4.5-air:free` | GLM 4.5 Air (free) | 128,000 | 96,000 | Reasoning |
 | `openrouter:minimax/minimax-m2.1` | MiniMax M2.1 | 204,800 | 131,072 | Reasoning, Tools |
+
+### Amazon Bedrock
+
+Bedrock model IDs are passed through unchanged and are not validated against the static registry. Use any model ID supported by your AWS account and region.
+
+| Model ID (example) | Notes |
+|--------------------|-------|
+| `bedrock:us.anthropic.claude-sonnet-4-5-20250929-v1:0` | Claude Sonnet 4.5 (US cross-region inference profile) |
+| `bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0` | Claude 3.5 Sonnet v2 |
+| `bedrock:anthropic.claude-3-haiku-20240307-v1:0` | Claude 3 Haiku |
+| `bedrock:meta.llama3-70b-instruct-v1:0` | Llama 3 70B Instruct |
+| `bedrock:mistral.mistral-large-2402-v1:0` | Mistral Large |
+| `bedrock:us.amazon.nova-pro-v1:0` | Amazon Nova Pro |
+
+See the [Amazon Bedrock model catalog](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html) for the full list. Model availability depends on the AWS region and on the [model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html) granted in your account.
+
+Authentication uses standard AWS environment variables (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION`, optional `AWS_SESSION_TOKEN`) or `AWS_BEARER_TOKEN_BEDROCK`. See the [Model Configuration guide](/guides/model-configuration#amazon-bedrock) for details.
 
 ## Custom Providers (Local LLMs)
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@ai-sdk/openai": "3.0.1",
     "@ai-sdk/openai-compatible": "^2.0.35",
     "@ai-sdk/provider": "^3.0.0",
+    "@aws-sdk/credential-providers": "^3.1034.0",
     "@clack/prompts": "^0.11.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@openauthjs/openauth": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "generate:models": "npx tsx scripts/generate-models.ts"
   },
   "dependencies": {
+    "@ai-sdk/amazon-bedrock": "^4.0.96",
     "@ai-sdk/anthropic": "3.0.1",
     "@ai-sdk/mcp": "1.0.1",
     "@ai-sdk/openai": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -58,13 +58,12 @@
     "generate:models": "npx tsx scripts/generate-models.ts"
   },
   "dependencies": {
-    "@ai-sdk/amazon-bedrock": "^4.0.96",
+    "@ai-sdk/amazon-bedrock": "4.0.96",
     "@ai-sdk/anthropic": "3.0.1",
     "@ai-sdk/mcp": "1.0.1",
     "@ai-sdk/openai": "3.0.1",
     "@ai-sdk/openai-compatible": "^2.0.35",
     "@ai-sdk/provider": "^3.0.0",
-    "@aws-sdk/credential-providers": "^3.1034.0",
     "@clack/prompts": "^0.11.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@openauthjs/openauth": "^0.4.3",
@@ -88,6 +87,9 @@
     "web-tree-sitter": "^0.26.3",
     "yaml": "^2.8.2",
     "zod": "^3.25.76"
+  },
+  "optionalDependencies": {
+    "@aws-sdk/credential-providers": "3.1034.0"
   },
   "devDependencies": {
     "@ai-sdk/devtools": "^0.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@ai-sdk/amazon-bedrock':
-        specifier: ^4.0.96
+        specifier: 4.0.96
         version: 4.0.96(zod@3.25.76)
       '@ai-sdk/anthropic':
         specifier: 3.0.1
@@ -26,9 +26,6 @@ importers:
       '@ai-sdk/provider':
         specifier: ^3.0.0
         version: 3.0.0
-      '@aws-sdk/credential-providers':
-        specifier: ^3.1034.0
-        version: 3.1034.0
       '@clack/prompts':
         specifier: ^0.11.0
         version: 0.11.0
@@ -98,6 +95,10 @@ importers:
       zod:
         specifier: ^3.25.76
         version: 3.25.76
+    optionalDependencies:
+      '@aws-sdk/credential-providers':
+        specifier: 3.1034.0
+        version: 3.1034.0
     devDependencies:
       '@ai-sdk/devtools':
         specifier: ^0.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@ai-sdk/provider':
         specifier: ^3.0.0
         version: 3.0.0
+      '@aws-sdk/credential-providers':
+        specifier: ^3.1034.0
+        version: 3.1034.0
       '@clack/prompts':
         specifier: ^0.11.0
         version: 0.11.0
@@ -187,12 +190,138 @@ packages:
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
     engines: {node: '>=16.0.0'}
 
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-cognito-identity@3.1034.0':
+    resolution: {integrity: sha512-GA2Xo1fNp4qnqTUI/IRGj/QmkQDXZyer3m/nu8WO7PgT3I+8/yWw2Vzw81HjAhOiF//YjNmpn10uHVg3ViSCRA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.3':
+    resolution: {integrity: sha512-W3aJJm2clu8OmsrwMOMnfof13O6LGnbknnZIQeSRbxjqKah2nVvkjbUBBZVhWrt08KC69H7WsINTdrxC/2SXQw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.26':
+    resolution: {integrity: sha512-eJyE408dpRkr8XSD1TjTQfOCK1r2o+W6vhsGHiL0PmJKr6LgCEP73epBbWbw6ZrJLKxlUYP44nVzY7cmwVlUgw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.29':
+    resolution: {integrity: sha512-rf+AlUxgTeSzQ/4zoS0D+Bt7XvgpY48PnWG8Yg/N9fdMgyK2Jaqa+6tLZp4MYMIMHkGrfAxnbSeb2YLMGFMg6g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.31':
+    resolution: {integrity: sha512-TR2/lQ3qKFj2EOrsiASzemsNEz2uzZ/SUBf48+U4Cr9a/FZlHfH/hwAeBJNBp1gMyJNxROJZhT3dn1cO+jnYfQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.33':
+    resolution: {integrity: sha512-UwdbJbOrgnOxZbshaNZ4DzX35h5wQd33MNYTGzWhN3ORG9lG9KQbDX6l6tDJSAdaGTktJoZPSritmUoW1rYkRA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.33':
+    resolution: {integrity: sha512-WyZuPVoDM1HGNl41eVg8HSSXIB+FGkuuK63GhDbh4TMdfWU03AciWvF/QqOVWvJtWVYaLddANJ+aUklVr2ieuw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.34':
+    resolution: {integrity: sha512-sPcisURibKU4x0PCWJkWF1KJYm49Cph9dCn/PAnG5FU0wq5Id3g2v7RuEWAtNlKv1Af4gUJYBVGOeNpSEEx41A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.29':
+    resolution: {integrity: sha512-DURisqWS3bUgiwMXTmzymVNGlcRW0FnbPZ3SZknhmxnCXm3n9idkTJ6T+Uir359KRKtJNFLRViskk8HsSVLi1w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.33':
+    resolution: {integrity: sha512-9y9obU4IQWru9f+NiiscUeyCe5ZmQav4FKEb1qfUNrik/C3BzBGUnHQWyPEyXjOX9cb+vx1TYx0qZBtinKdzTA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.33':
+    resolution: {integrity: sha512-RazhlN0YAkna2T2p2v4YuuRlVBVRNo8V0SL+9JePTWDndEUAeOBAjYeQfAMbtDyCh120+zA0Op6V0jS4dw2+iw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-providers@3.1034.0':
+    resolution: {integrity: sha512-xTmpZN3i4cZEgjJNQhA8CYmxKtW95ZAhh9wINe2b6ffQzbaXBLkuvfz/fhWEezl4P8uv2qWO8J+DEDms6wqL9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.972.10':
+    resolution: {integrity: sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-logger@3.972.10':
+    resolution: {integrity: sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    resolution: {integrity: sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.32':
+    resolution: {integrity: sha512-dc2O2x0V5pGJhmdQYQveUIFtMZsur7GrGuSgoKM4oQJuEcfvwnJ3sj+ip6WnxR5l6TrX5zkl4KgcgswOy3wAzQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.33':
+    resolution: {integrity: sha512-mqtT3Fo7xanWMk2SbAcKLGGI/q1GHWNrExBj7cnWP2W2mkTMheXB4ntJvwPZ1UxPrQobrsv2dWFXmaOJeSOiDg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.1':
+    resolution: {integrity: sha512-Afc9hc2WZs3X4Jb8dnxyuYiZsLoWRO51roTCRf497gPnAKN2WRdXANu1vaVCTzwnDMOYFXb/cYv4ZSjxqAqcKA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.13':
+    resolution: {integrity: sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.20':
+    resolution: {integrity: sha512-MEj6DhEcaO8RgVtFCJ+xpCQnZC3Iesr09avdY75qkMQfckQULu447IegK7Rs1MCGerVBfKnJQ4q+pQq9hI5lng==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1034.0':
+    resolution: {integrity: sha512-8E+KGcD4ET0H9FXJ2/ZWbfFnQNYEkTZZYJxAs1lkdJlve1AYuqaydInIFfvNgoz5GbYtzbK8/ugsSMu5wPm6kA==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.8':
     resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
     engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.996.8':
+    resolution: {integrity: sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    resolution: {integrity: sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==}
+
+  '@aws-sdk/util-user-agent-node@3.973.19':
+    resolution: {integrity: sha512-ZAfHjpzdbrzkAftC139JoYGfXzDh5HY+AxRzw8pGJ8cULsf+l721sKAMK8mV5NvRETaW/BwghSwQhGgoNgrxMw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.972.18':
+    resolution: {integrity: sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -625,8 +754,32 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
+  '@smithy/config-resolver@4.4.17':
+    resolution: {integrity: sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.23.16':
+    resolution: {integrity: sha512-JStomOrINQA1VqNEopLsgcdgwd42au7mykKqVr30XFw89wLt9sDxJDi4djVPRwQmmzyTGy/uOvTc2ultMpFi1w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.2.14':
+    resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/eventstream-codec@4.2.14':
     resolution: {integrity: sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.3.17':
+    resolution: {integrity: sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.2.14':
+    resolution: {integrity: sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.14':
+    resolution: {integrity: sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
@@ -637,8 +790,84 @@ packages:
     resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/middleware-content-length@4.2.14':
+    resolution: {integrity: sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.4.31':
+    resolution: {integrity: sha512-KJPdCIN2kOE2aGmqZd7eUTr4WQwOGgtLWgUkswGJggs7rBcQYQjcZMEDa3C0DwbOiXS9L8/wDoQHkfxBYLfiLw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.5.4':
+    resolution: {integrity: sha512-/z7nIFK+ZRW3Ie/l3NEVGdy34LvmEOzBrtBAvgWZ/4PrKX0xP3kWm8pkfcwUk523SqxZhdbQP9JSXgjF77Uhpw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.19':
+    resolution: {integrity: sha512-Q6y+W9h3iYVMCKWDoVge+OC1LKFqbEKaq8SIWG2X2bWJRpd/6dDLyICcNLT6PbjH3Rr6bmg/SeDB25XFOFfeEw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.2.14':
+    resolution: {integrity: sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.14':
+    resolution: {integrity: sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.6.0':
+    resolution: {integrity: sha512-P734cAoTFtuGfWa/R3jgBnGlURt2w9bYEBwQNMKf58sRM9RShirB2mKwLsVP+jlG/wxpCu8abv8NxdUts8tdLA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.14':
+    resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.3.14':
+    resolution: {integrity: sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.14':
+    resolution: {integrity: sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-parser@4.2.14':
+    resolution: {integrity: sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.3.0':
+    resolution: {integrity: sha512-9jKsBYQRPR0xBLgc2415RsA5PIcP2sis4oBdN9s0D13cg1B1284mNTjx9Yc+BEERXzuPm5ObktI96OxsKh8E9A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.4.9':
+    resolution: {integrity: sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.3.14':
+    resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.12.12':
+    resolution: {integrity: sha512-daO7SJn4eM6ArbmrEs+/BTbH7af8AEbSL3OMQdcRvvn8tuUcR5rU2n6DgxIV53aXMS42uwK8NgKKCh5XgqYOPQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/types@4.14.1':
     resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.14':
+    resolution: {integrity: sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.3.2':
+    resolution: {integrity: sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-browser@4.2.2':
+    resolution: {integrity: sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.2.3':
+    resolution: {integrity: sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-buffer-from@2.2.0':
@@ -649,8 +878,40 @@ packages:
     resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-config-provider@4.2.2':
+    resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-browser@4.3.48':
+    resolution: {integrity: sha512-hxVRVPYaRDWa6YQdse1aWX1qrksmLsvNyGBKdc32q4jFzSjxYVNWfstknAfR228TnzS4tzgswXRuYIbhXBuXFQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.2.53':
+    resolution: {integrity: sha512-ybgCk+9JdBq8pYC8Y6U5fjyS8e4sboyAShetxPNL0rRBtaVl56GSFAxsolVBIea1tXR4LPIzL8i6xqmcf0+DCQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.4.2':
+    resolution: {integrity: sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-hex-encoding@4.2.2':
     resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.2.14':
+    resolution: {integrity: sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.3.3':
+    resolution: {integrity: sha512-idjUvd4M9Jj6rXkhqw4H4reHoweuK4ZxYWyOrEp4N2rOF5VtaOlQGLDQJva/8WanNXk9ScQtsAb7o5UHGvFm4A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.24':
+    resolution: {integrity: sha512-na5vv2mBSDzXewLEEoWGI7LQQkfpmFEomBsmOpzLFjqGctm0iMwXY5lAwesY9pIaErkccW0qzEOUcYP+WKneXg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-uri-escape@4.2.2':
+    resolution: {integrity: sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-utf8@2.3.0':
@@ -659,6 +920,10 @@ packages:
 
   '@smithy/util-utf8@4.2.2':
     resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/uuid@1.1.2':
+    resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
     engines: {node: '>=18.0.0'}
 
   '@standard-schema/spec@1.0.0-beta.3':
@@ -792,6 +1057,9 @@ packages:
   body-parser@2.2.0:
     resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
     engines: {node: '>=18'}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   boxen@8.0.1:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
@@ -1169,6 +1437,13 @@ packages:
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-xml-builder@1.1.5:
+    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
+
+  fast-xml-parser@5.5.8:
+    resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
+    hasBin: true
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -1820,6 +2095,10 @@ packages:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -2159,6 +2438,9 @@ packages:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
 
+  strnum@2.2.3:
+    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
+
   stubborn-fs@1.2.5:
     resolution: {integrity: sha512-H2N9c26eXjzL/S/K+i/RHHcFanE74dptvvjM8iwzwbVcWY/zjBbgRqF3K0DY4+OD+uTTASTBvDoxPDaPN02D7g==}
 
@@ -2472,16 +2754,398 @@ snapshots:
       '@aws-sdk/types': 3.973.8
       tslib: 2.8.1
 
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
   '@aws-crypto/util@5.2.0':
     dependencies:
       '@aws-sdk/types': 3.973.8
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
+  '@aws-sdk/client-cognito-identity@3.1034.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.3
+      '@aws-sdk/credential-provider-node': 3.972.34
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.33
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.19
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.16
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.31
+      '@smithy/middleware-retry': 4.5.4
+      '@smithy/middleware-serde': 4.2.19
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.0
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.12
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.48
+      '@smithy/util-defaults-mode-node': 4.2.53
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.3
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/core@3.974.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.18
+      '@smithy/core': 3.23.16
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.12
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.3
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.26':
+    dependencies:
+      '@aws-sdk/nested-clients': 3.997.1
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-env@3.972.29':
+    dependencies:
+      '@aws-sdk/core': 3.974.3
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.31':
+    dependencies:
+      '@aws-sdk/core': 3.974.3
+      '@aws-sdk/types': 3.973.8
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.0
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.12
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.24
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.33':
+    dependencies:
+      '@aws-sdk/core': 3.974.3
+      '@aws-sdk/credential-provider-env': 3.972.29
+      '@aws-sdk/credential-provider-http': 3.972.31
+      '@aws-sdk/credential-provider-login': 3.972.33
+      '@aws-sdk/credential-provider-process': 3.972.29
+      '@aws-sdk/credential-provider-sso': 3.972.33
+      '@aws-sdk/credential-provider-web-identity': 3.972.33
+      '@aws-sdk/nested-clients': 3.997.1
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.33':
+    dependencies:
+      '@aws-sdk/core': 3.974.3
+      '@aws-sdk/nested-clients': 3.997.1
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.972.34':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.29
+      '@aws-sdk/credential-provider-http': 3.972.31
+      '@aws-sdk/credential-provider-ini': 3.972.33
+      '@aws-sdk/credential-provider-process': 3.972.29
+      '@aws-sdk/credential-provider-sso': 3.972.33
+      '@aws-sdk/credential-provider-web-identity': 3.972.33
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-process@3.972.29':
+    dependencies:
+      '@aws-sdk/core': 3.974.3
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.33':
+    dependencies:
+      '@aws-sdk/core': 3.974.3
+      '@aws-sdk/nested-clients': 3.997.1
+      '@aws-sdk/token-providers': 3.1034.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.33':
+    dependencies:
+      '@aws-sdk/core': 3.974.3
+      '@aws-sdk/nested-clients': 3.997.1
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-providers@3.1034.0':
+    dependencies:
+      '@aws-sdk/client-cognito-identity': 3.1034.0
+      '@aws-sdk/core': 3.974.3
+      '@aws-sdk/credential-provider-cognito-identity': 3.972.26
+      '@aws-sdk/credential-provider-env': 3.972.29
+      '@aws-sdk/credential-provider-http': 3.972.31
+      '@aws-sdk/credential-provider-ini': 3.972.33
+      '@aws-sdk/credential-provider-login': 3.972.33
+      '@aws-sdk/credential-provider-node': 3.972.34
+      '@aws-sdk/credential-provider-process': 3.972.29
+      '@aws-sdk/credential-provider-sso': 3.972.33
+      '@aws-sdk/credential-provider-web-identity': 3.972.33
+      '@aws-sdk/nested-clients': 3.997.1
+      '@aws-sdk/types': 3.973.8
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.16
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/middleware-host-header@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-logger@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.32':
+    dependencies:
+      '@aws-sdk/core': 3.974.3
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/core': 3.23.16
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.12
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.24
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.33':
+    dependencies:
+      '@aws-sdk/core': 3.974.3
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@smithy/core': 3.23.16
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-retry': 4.3.3
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.1':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.3
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.33
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.20
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.19
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.16
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.31
+      '@smithy/middleware-retry': 4.5.4
+      '@smithy/middleware-serde': 4.2.19
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.0
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.12
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.48
+      '@smithy/util-defaults-mode-node': 4.2.53
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.3
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.972.13':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.20':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.972.32
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1034.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.3
+      '@aws-sdk/nested-clients': 3.997.1
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/types@3.973.8':
     dependencies:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.996.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-endpoints': 3.4.2
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.973.19':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.33
+      '@aws-sdk/types': 3.973.8
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.18':
+    dependencies:
+      '@smithy/types': 4.14.1
+      fast-xml-parser: 5.5.8
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -2846,11 +3510,61 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
+  '@smithy/config-resolver@4.4.17':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/core@3.23.16':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.24
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.2.14':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      tslib: 2.8.1
+
   '@smithy/eventstream-codec@4.2.14':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
       '@smithy/types': 4.14.1
       '@smithy/util-hex-encoding': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.3.17':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/hash-node@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/is-array-buffer@2.2.0':
@@ -2861,7 +3575,134 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@smithy/middleware-content-length@4.2.14':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.4.31':
+    dependencies:
+      '@smithy/core': 3.23.16
+      '@smithy/middleware-serde': 4.2.19
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-middleware': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/middleware-retry@4.5.4':
+    dependencies:
+      '@smithy/core': 3.23.16
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/service-error-classification': 4.3.0
+      '@smithy/smithy-client': 4.12.12
+      '@smithy/types': 4.14.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.3
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.2.19':
+    dependencies:
+      '@smithy/core': 3.23.16
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.14':
+    dependencies:
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.6.0':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/property-provider@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/querystring-builder@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-uri-escape': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/service-error-classification@4.3.0':
+    dependencies:
+      '@smithy/types': 4.14.1
+
+  '@smithy/shared-ini-file-loader@4.4.9':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.3.14':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-uri-escape': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.12.12':
+    dependencies:
+      '@smithy/core': 3.23.16
+      '@smithy/middleware-endpoint': 4.4.31
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.24
+      tslib: 2.8.1
+
   '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.14':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.3.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-browser@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.2.3':
     dependencies:
       tslib: 2.8.1
 
@@ -2875,7 +3716,60 @@ snapshots:
       '@smithy/is-array-buffer': 4.2.2
       tslib: 2.8.1
 
+  '@smithy/util-config-provider@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-browser@4.3.48':
+    dependencies:
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.12
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.2.53':
+    dependencies:
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.12
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.4.2':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/util-hex-encoding@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.3.3':
+    dependencies:
+      '@smithy/service-error-classification': 4.3.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.24':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.0
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-uri-escape@4.2.2':
     dependencies:
       tslib: 2.8.1
 
@@ -2887,6 +3781,10 @@ snapshots:
   '@smithy/util-utf8@4.2.2':
     dependencies:
       '@smithy/util-buffer-from': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/uuid@1.1.2':
+    dependencies:
       tslib: 2.8.1
 
   '@standard-schema/spec@1.0.0-beta.3': {}
@@ -3021,6 +3919,8 @@ snapshots:
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  bowser@2.14.1: {}
 
   boxen@8.0.1:
     dependencies:
@@ -3425,6 +4325,16 @@ snapshots:
       micromatch: 4.0.8
 
   fast-json-stable-stringify@2.1.0: {}
+
+  fast-xml-builder@1.1.5:
+    dependencies:
+      path-expression-matcher: 1.5.0
+
+  fast-xml-parser@5.5.8:
+    dependencies:
+      fast-xml-builder: 1.1.5
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
 
   fastq@1.19.1:
     dependencies:
@@ -4081,6 +4991,8 @@ snapshots:
 
   path-exists@5.0.0: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
@@ -4437,6 +5349,8 @@ snapshots:
   strip-final-newline@3.0.0: {}
 
   strip-json-comments@2.0.1: {}
+
+  strnum@2.2.3: {}
 
   stubborn-fs@1.2.5: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/amazon-bedrock':
+        specifier: ^4.0.96
+        version: 4.0.96(zod@3.25.76)
       '@ai-sdk/anthropic':
         specifier: 3.0.1
         version: 3.0.1(zod@3.25.76)
@@ -108,8 +111,20 @@ importers:
 
 packages:
 
+  '@ai-sdk/amazon-bedrock@4.0.96':
+    resolution: {integrity: sha512-Mc4Ias2jRMD1jOB6xWtKNPdhECeuCZyIlbr9EAGfBnyBt++sS13ziZh9qv9TdyMCAZJ7xoQcpbchoRJcKwPdpA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/anthropic@3.0.1':
     resolution: {integrity: sha512-MOiwKs76ilEmau/WRMnGWlheTUoB+cbvXCse+SAtpW5ATLreInsuYlspLABn12Dxu3w1Xzke1dT+tmEnxhy9SA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/anthropic@3.0.71':
+    resolution: {integrity: sha512-bUWOzrzR0gJKJO/PLGMR4uH2dqEgqGhrsCV+sSpk4KtOEnUQlfjZI/F7BFlqSvVpFbjdgYRRLysAeEZpJ6S1lg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -154,6 +169,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.23':
+    resolution: {integrity: sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@3.0.0':
     resolution: {integrity: sha512-m9ka3ptkPQbaHHZHqDXDF9C9B5/Mav0KTdky1k2HZ3/nrW2t1AgObxIVPyGDWQNS9FXT/FS6PIoSjpcP/No8rQ==}
     engines: {node: '>=18'}
@@ -161,6 +182,17 @@ packages:
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -592,6 +624,42 @@ packages:
   '@sindresorhus/merge-streams@2.3.0':
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
+
+  '@smithy/eventstream-codec@4.2.14':
+    resolution: {integrity: sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.2.2':
+    resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.1':
+    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@4.2.2':
+    resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.2':
+    resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.2.2':
+    resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
+    engines: {node: '>=18.0.0'}
 
   '@standard-schema/spec@1.0.0-beta.3':
     resolution: {integrity: sha512-0ifF3BjA1E8SY9C+nUew8RefNOIq0cDlYALPty4rhUm8Rrl6tCM8hBT4bhGhx7I7iXD0uAgt50lgo8dD73ACMw==}
@@ -2315,10 +2383,26 @@ packages:
 
 snapshots:
 
+  '@ai-sdk/amazon-bedrock@4.0.96(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/anthropic': 3.0.71(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
+      '@smithy/eventstream-codec': 4.2.14
+      '@smithy/util-utf8': 4.2.2
+      aws4fetch: 1.0.20
+      zod: 3.25.76
+
   '@ai-sdk/anthropic@3.0.1(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.0
       '@ai-sdk/provider-utils': 4.0.1(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/anthropic@3.0.71(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
       zod: 3.25.76
 
   '@ai-sdk/devtools@0.0.1':
@@ -2367,6 +2451,13 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 3.25.76
 
+  '@ai-sdk/provider-utils@4.0.23(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 3.25.76
+
   '@ai-sdk/provider@3.0.0':
     dependencies:
       json-schema: 0.4.0
@@ -2374,6 +2465,23 @@ snapshots:
   '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.8':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -2737,6 +2845,49 @@ snapshots:
       - zenObservable
 
   '@sindresorhus/merge-streams@2.3.0': {}
+
+  '@smithy/eventstream-codec@4.2.14':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@4.2.2':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.2.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      tslib: 2.8.1
 
   '@standard-schema/spec@1.0.0-beta.3': {}
 

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -46,7 +46,9 @@ export function createProviderCommand(): Command {
       process.stdout.write("   Set API keys directly in your environment:\n");
       process.stdout.write("   • ANTHROPIC_API_KEY     - For Anthropic Claude models\n");
       process.stdout.write("   • OPENAI_API_KEY        - For OpenAI GPT models\n");
-      process.stdout.write("   • OPENROUTER_API_KEY    - For OpenRouter (multiple models)\n\n");
+      process.stdout.write("   • OPENROUTER_API_KEY    - For OpenRouter (multiple models)\n");
+      process.stdout.write("   • AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY + AWS_REGION\n");
+      process.stdout.write("                           - For Amazon Bedrock (or AWS_BEARER_TOKEN_BEDROCK)\n\n");
       
       process.stdout.write("ENVIRONMENT VARIABLE SETUP:\n");
       process.stdout.write("─".repeat(40) + "\n");
@@ -90,6 +92,7 @@ export function createProviderCommand(): Command {
       process.stdout.write("• Anthropic:   https://console.anthropic.com/account/keys\n");
       process.stdout.write("• OpenAI:      https://platform.openai.com/api-keys\n");
       process.stdout.write("• OpenRouter:  https://openrouter.ai/keys\n");
+      process.stdout.write("• AWS Bedrock: https://console.aws.amazon.com/iam (create access key with AmazonBedrockFullAccess)\n");
     });
 
   authCmd

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -102,7 +102,7 @@ export function createProviderCommand(): Command {
     .option("--key <key>", "Optional API key for the endpoint")
     .action(async (name: string, options: { url: string; key?: string }) => {
       // Validate name doesn't conflict with built-in providers
-      const reserved = ["anthropic", "openai", "openrouter", "demo"];
+      const reserved = ["anthropic", "openai", "openrouter", "demo", "bedrock"];
       if (reserved.includes(name.toLowerCase())) {
         logger.error(`Cannot use reserved provider name '${name}'. Reserved: ${reserved.join(", ")}`);
         process.exit(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -370,7 +370,7 @@ program
         }
 
         const [provider] = modelParts;
-        const builtinProviders = ['anthropic', 'openai', 'openrouter', 'demo'];
+        const builtinProviders = ['anthropic', 'openai', 'openrouter', 'demo', 'bedrock'];
         if (!builtinProviders.includes(provider)) {
           // Check if it's a custom provider
           const customProvider = await AuthStorage.getCustomProvider(provider);

--- a/src/models.ts
+++ b/src/models.ts
@@ -418,21 +418,21 @@ export async function createModel(modelString: string) {
     return await maybeWrapWithDevTools(createDemoModel(config.modelName));
 
   } else if (config.provider === 'bedrock') {
-    // Amazon Bedrock - supports SigV4 (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY)
-    // or Bearer token (AWS_BEARER_TOKEN_BEDROCK), plus AWS_REGION/AWS_SESSION_TOKEN.
-    // The provider reads these from the environment by default.
+    // Amazon Bedrock supports three authentication modes (in priority order):
+    //   1. AWS_BEARER_TOKEN_BEDROCK   - Bedrock API key (Bearer auth)
+    //   2. AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY (+ optional AWS_SESSION_TOKEN)
+    //      - Static IAM credentials (SigV4)
+    //   3. AWS SDK credential provider chain - resolves AWS_PROFILE,
+    //      ~/.aws/credentials, SSO cache, EC2/ECS/EKS instance roles, env vars, etc.
     const region = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION;
     const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
     const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
     const bearerToken = process.env.AWS_BEARER_TOKEN_BEDROCK;
+    const hasStaticCreds = Boolean(accessKeyId && secretAccessKey);
+    // Use the SDK credential provider chain when no static creds are present
+    // (covers AWS_PROFILE / SSO / instance roles / etc.)
+    const useCredentialChain = !bearerToken && !hasStaticCreds;
 
-    if (!bearerToken && !(accessKeyId && secretAccessKey)) {
-      throw new AuthenticationError(
-        'bedrock',
-        'AWS_ACCESS_KEY_ID',
-        'No authentication found for Amazon Bedrock. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY (and AWS_REGION), or AWS_BEARER_TOKEN_BEDROCK'
-      );
-    }
     if (!region) {
       throw new AuthenticationError(
         'bedrock',
@@ -441,19 +441,36 @@ export async function createModel(modelString: string) {
       );
     }
 
-    logger.debug(
-      bearerToken
-        ? 'Using AWS_BEARER_TOKEN_BEDROCK for Amazon Bedrock authentication'
-        : 'Using AWS access key for Amazon Bedrock authentication'
-    );
+    const bedrockOptions: Record<string, unknown> = { region };
+    if (bearerToken) {
+      logger.debug('Using AWS_BEARER_TOKEN_BEDROCK for Amazon Bedrock authentication');
+      bedrockOptions.apiKey = bearerToken;
+    } else if (hasStaticCreds) {
+      logger.debug('Using static AWS access keys for Amazon Bedrock authentication');
+      bedrockOptions.accessKeyId = accessKeyId;
+      bedrockOptions.secretAccessKey = secretAccessKey;
+      if (process.env.AWS_SESSION_TOKEN) {
+        bedrockOptions.sessionToken = process.env.AWS_SESSION_TOKEN;
+      }
+    } else if (useCredentialChain) {
+      logger.debug(
+        process.env.AWS_PROFILE
+          ? `Using AWS SDK credential chain for Amazon Bedrock (AWS_PROFILE=${process.env.AWS_PROFILE})`
+          : 'Using AWS SDK credential chain for Amazon Bedrock'
+      );
+      try {
+        const { fromNodeProviderChain } = await import('@aws-sdk/credential-providers');
+        bedrockOptions.credentialProvider = fromNodeProviderChain();
+      } catch (error) {
+        throw new AuthenticationError(
+          'bedrock',
+          'AWS_ACCESS_KEY_ID',
+          `No authentication found for Amazon Bedrock and @aws-sdk/credential-providers is not available (${error instanceof Error ? error.message : String(error)}). Set AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY, AWS_BEARER_TOKEN_BEDROCK, or install @aws-sdk/credential-providers and configure AWS_PROFILE`
+        );
+      }
+    }
 
-    const bedrock = createAmazonBedrock({
-      region,
-      ...(accessKeyId ? { accessKeyId } : {}),
-      ...(secretAccessKey ? { secretAccessKey } : {}),
-      ...(process.env.AWS_SESSION_TOKEN ? { sessionToken: process.env.AWS_SESSION_TOKEN } : {}),
-      ...(bearerToken ? { apiKey: bearerToken } : {}),
-    });
+    const bedrock = createAmazonBedrock(bedrockOptions as Parameters<typeof createAmazonBedrock>[0]);
     return await maybeWrapWithDevTools(bedrock(config.modelName));
 
   } else {

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,6 +1,7 @@
 import { createOpenAI } from '@ai-sdk/openai';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { createAnthropic } from '@ai-sdk/anthropic';
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import { wrapLanguageModel } from 'ai';
 import { AnthropicAuth } from './auth/anthropic';
 import { CodexAuth } from './auth/codex';
@@ -112,6 +113,12 @@ export function parseModelConfig(modelString: string): ModelConfig {
 
   const provider = modelString.slice(0, firstColon);
   const rest = modelString.slice(firstColon + 1);
+
+  // Bedrock model IDs contain colons (e.g. "anthropic.claude-3-5-sonnet-20241022-v2:0"),
+  // so we keep the full remainder as the model name and don't support env-suffix syntax.
+  if (provider === 'bedrock') {
+    return { provider, modelName: rest };
+  }
 
   // Built-in providers support the env suffix syntax: provider:model:env
   const builtinProviders = ['anthropic', 'openai', 'openrouter', 'demo'];
@@ -409,6 +416,45 @@ export async function createModel(modelString: string) {
     // Demo provider - no authentication required
     logger.debug('Using demo provider (no API key required)');
     return await maybeWrapWithDevTools(createDemoModel(config.modelName));
+
+  } else if (config.provider === 'bedrock') {
+    // Amazon Bedrock - supports SigV4 (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY)
+    // or Bearer token (AWS_BEARER_TOKEN_BEDROCK), plus AWS_REGION/AWS_SESSION_TOKEN.
+    // The provider reads these from the environment by default.
+    const region = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION;
+    const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
+    const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+    const bearerToken = process.env.AWS_BEARER_TOKEN_BEDROCK;
+
+    if (!bearerToken && !(accessKeyId && secretAccessKey)) {
+      throw new AuthenticationError(
+        'bedrock',
+        'AWS_ACCESS_KEY_ID',
+        'No authentication found for Amazon Bedrock. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY (and AWS_REGION), or AWS_BEARER_TOKEN_BEDROCK'
+      );
+    }
+    if (!region) {
+      throw new AuthenticationError(
+        'bedrock',
+        'AWS_REGION',
+        'No AWS region found for Amazon Bedrock. Set AWS_REGION (or AWS_DEFAULT_REGION)'
+      );
+    }
+
+    logger.debug(
+      bearerToken
+        ? 'Using AWS_BEARER_TOKEN_BEDROCK for Amazon Bedrock authentication'
+        : 'Using AWS access key for Amazon Bedrock authentication'
+    );
+
+    const bedrock = createAmazonBedrock({
+      region,
+      ...(accessKeyId ? { accessKeyId } : {}),
+      ...(secretAccessKey ? { secretAccessKey } : {}),
+      ...(process.env.AWS_SESSION_TOKEN ? { sessionToken: process.env.AWS_SESSION_TOKEN } : {}),
+      ...(bearerToken ? { apiKey: bearerToken } : {}),
+    });
+    return await maybeWrapWithDevTools(bedrock(config.modelName));
 
   } else {
     // Check for custom provider

--- a/src/models.ts
+++ b/src/models.ts
@@ -441,11 +441,11 @@ export async function createModel(modelString: string) {
       );
     }
 
-    const bedrockOptions: Record<string, unknown> = { region };
+    const bedrockOptions: Parameters<typeof createAmazonBedrock>[0] = { region };
     if (bearerToken) {
       logger.debug('Using AWS_BEARER_TOKEN_BEDROCK for Amazon Bedrock authentication');
       bedrockOptions.apiKey = bearerToken;
-    } else if (hasStaticCreds) {
+    } else if (accessKeyId && secretAccessKey) {
       logger.debug('Using static AWS access keys for Amazon Bedrock authentication');
       bedrockOptions.accessKeyId = accessKeyId;
       bedrockOptions.secretAccessKey = secretAccessKey;
@@ -465,12 +465,12 @@ export async function createModel(modelString: string) {
         throw new AuthenticationError(
           'bedrock',
           'AWS_ACCESS_KEY_ID',
-          `No authentication found for Amazon Bedrock and @aws-sdk/credential-providers is not available (${error instanceof Error ? error.message : String(error)}). Set AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY, AWS_BEARER_TOKEN_BEDROCK, or install @aws-sdk/credential-providers and configure AWS_PROFILE`
+          `No authentication found for Amazon Bedrock and @aws-sdk/credential-providers is not available (${error instanceof Error ? error.message : String(error)}). Set AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY, AWS_BEARER_TOKEN_BEDROCK, or install @aws-sdk/credential-providers to use AWS_PROFILE / SSO / instance roles: pnpm add @aws-sdk/credential-providers`
         );
       }
     }
 
-    const bedrock = createAmazonBedrock(bedrockOptions as Parameters<typeof createAmazonBedrock>[0]);
+    const bedrock = createAmazonBedrock(bedrockOptions);
     return await maybeWrapWithDevTools(bedrock(config.modelName));
 
   } else {

--- a/src/runner/execution.ts
+++ b/src/runner/execution.ts
@@ -65,7 +65,7 @@ export async function* executeAgentCore(
 
     // Extract provider options based on model provider
     const provider = agent.config.model.split(':')[0];
-    const isCustomProvider = !['anthropic', 'openai', 'openrouter', 'demo'].includes(provider);
+    const isCustomProvider = !['anthropic', 'openai', 'openrouter', 'demo', 'bedrock'].includes(provider);
 
     // Only include provider options if they exist and match the model provider
     let providerOptions: any = undefined;

--- a/src/utils/model-utils.ts
+++ b/src/utils/model-utils.ts
@@ -74,6 +74,11 @@ export function warnIfModelNotInRegistry(modelString: string): string {
     return modelString;
   }
 
+  // Skip validation for Bedrock - model IDs are AWS-specific and not in our registry
+  if (parts.length >= 2 && parts[0] === 'bedrock') {
+    return modelString;
+  }
+
   const result = validateModel(modelString);
 
   if (!result.valid) {

--- a/tests/model-utils.test.ts
+++ b/tests/model-utils.test.ts
@@ -108,4 +108,14 @@ describe("warnIfModelNotInRegistry (custom provider skip)", () => {
     const result = warnIfModelNotInRegistry("anthropic:claude-sonnet-4-6");
     expect(result).toBe("anthropic:claude-sonnet-4-6");
   });
+
+  it("skips validation for bedrock models (not in registry)", async () => {
+    await loadCustomProviderNames();
+    // Bedrock model IDs are AWS-specific and intentionally not in the registry,
+    // so warnIfModelNotInRegistry should return the string unchanged.
+    const result = warnIfModelNotInRegistry(
+      "bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0"
+    );
+    expect(result).toBe("bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0");
+  });
 });

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -145,6 +145,7 @@ describe('createModel Amazon Bedrock', () => {
     AWS_SECRET_ACCESS_KEY: undefined as string | undefined,
     AWS_SESSION_TOKEN: undefined as string | undefined,
     AWS_BEARER_TOKEN_BEDROCK: undefined as string | undefined,
+    AWS_PROFILE: undefined as string | undefined,
   };
 
   it('creates a Bedrock model with AWS access keys', async () => {
@@ -185,14 +186,17 @@ describe('createModel Amazon Bedrock', () => {
     });
   });
 
-  it('throws AuthenticationError when no credentials are provided', async () => {
+  it('uses the AWS SDK credential chain when no static credentials are set', async () => {
+    // No AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_BEARER_TOKEN_BEDROCK,
+    // only AWS_PROFILE + region — should resolve via fromNodeProviderChain().
     await withEnv({
       ...bedrockEnvKeys,
-      AWS_REGION: 'us-east-1',
+      AWS_REGION: 'eu-west-1',
+      AWS_PROFILE: 'some-profile',
     }, async () => {
-      await expect(
-        createModel('bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0')
-      ).rejects.toBeInstanceOf(AuthenticationError);
+      const model = await createModel('bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0');
+      expect(model).toBeDefined();
+      expect(model.modelId).toBe('anthropic.claude-3-5-sonnet-20241022-v2:0');
     });
   });
 
@@ -201,18 +205,6 @@ describe('createModel Amazon Bedrock', () => {
       ...bedrockEnvKeys,
       AWS_ACCESS_KEY_ID: 'AKIAEXAMPLE',
       AWS_SECRET_ACCESS_KEY: 'secret',
-    }, async () => {
-      await expect(
-        createModel('bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0')
-      ).rejects.toBeInstanceOf(AuthenticationError);
-    });
-  });
-
-  it('throws AuthenticationError when only access key id is set', async () => {
-    await withEnv({
-      ...bedrockEnvKeys,
-      AWS_REGION: 'us-east-1',
-      AWS_ACCESS_KEY_ID: 'AKIAEXAMPLE',
     }, async () => {
       await expect(
         createModel('bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0')

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { createModel } from '../src/models';
+import { createModel, AuthenticationError } from '../src/models';
 import { AnthropicAuth } from '../src/auth/anthropic';
 import { CodexAuth } from '../src/auth/codex';
 
@@ -133,6 +133,90 @@ describe('createModel base URL configuration', () => {
       } finally {
         AnthropicAuth.access = originalAccess;
       }
+    });
+  });
+});
+
+describe('createModel Amazon Bedrock', () => {
+  const bedrockEnvKeys = {
+    AWS_REGION: undefined as string | undefined,
+    AWS_DEFAULT_REGION: undefined as string | undefined,
+    AWS_ACCESS_KEY_ID: undefined as string | undefined,
+    AWS_SECRET_ACCESS_KEY: undefined as string | undefined,
+    AWS_SESSION_TOKEN: undefined as string | undefined,
+    AWS_BEARER_TOKEN_BEDROCK: undefined as string | undefined,
+  };
+
+  it('creates a Bedrock model with AWS access keys', async () => {
+    await withEnv({
+      ...bedrockEnvKeys,
+      AWS_REGION: 'us-east-1',
+      AWS_ACCESS_KEY_ID: 'AKIAEXAMPLE',
+      AWS_SECRET_ACCESS_KEY: 'secret',
+    }, async () => {
+      const model = await createModel('bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0');
+      expect(model).toBeDefined();
+      expect(model.modelId).toBe('anthropic.claude-3-5-sonnet-20241022-v2:0');
+      expect(model.provider).toContain('bedrock');
+    });
+  });
+
+  it('creates a Bedrock model with AWS_BEARER_TOKEN_BEDROCK', async () => {
+    await withEnv({
+      ...bedrockEnvKeys,
+      AWS_REGION: 'us-east-1',
+      AWS_BEARER_TOKEN_BEDROCK: 'bearer-token',
+    }, async () => {
+      const model = await createModel('bedrock:meta.llama3-70b-instruct-v1:0');
+      expect(model).toBeDefined();
+      expect(model.modelId).toBe('meta.llama3-70b-instruct-v1:0');
+    });
+  });
+
+  it('falls back to AWS_DEFAULT_REGION when AWS_REGION is unset', async () => {
+    await withEnv({
+      ...bedrockEnvKeys,
+      AWS_DEFAULT_REGION: 'eu-west-1',
+      AWS_ACCESS_KEY_ID: 'AKIAEXAMPLE',
+      AWS_SECRET_ACCESS_KEY: 'secret',
+    }, async () => {
+      const model = await createModel('bedrock:anthropic.claude-3-haiku-20240307-v1:0');
+      expect(model).toBeDefined();
+    });
+  });
+
+  it('throws AuthenticationError when no credentials are provided', async () => {
+    await withEnv({
+      ...bedrockEnvKeys,
+      AWS_REGION: 'us-east-1',
+    }, async () => {
+      await expect(
+        createModel('bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0')
+      ).rejects.toBeInstanceOf(AuthenticationError);
+    });
+  });
+
+  it('throws AuthenticationError when region is missing', async () => {
+    await withEnv({
+      ...bedrockEnvKeys,
+      AWS_ACCESS_KEY_ID: 'AKIAEXAMPLE',
+      AWS_SECRET_ACCESS_KEY: 'secret',
+    }, async () => {
+      await expect(
+        createModel('bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0')
+      ).rejects.toBeInstanceOf(AuthenticationError);
+    });
+  });
+
+  it('throws AuthenticationError when only access key id is set', async () => {
+    await withEnv({
+      ...bedrockEnvKeys,
+      AWS_REGION: 'us-east-1',
+      AWS_ACCESS_KEY_ID: 'AKIAEXAMPLE',
+    }, async () => {
+      await expect(
+        createModel('bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0')
+      ).rejects.toBeInstanceOf(AuthenticationError);
     });
   });
 });

--- a/tests/parse-model-config.test.ts
+++ b/tests/parse-model-config.test.ts
@@ -90,4 +90,34 @@ describe("parseModelConfig", () => {
       expect(result.modelName).toBe("TheBloke/Mistral-7B-Instruct:q4_0");
     });
   });
+
+  describe("bedrock provider", () => {
+    it("preserves colons in Bedrock model IDs", () => {
+      const result = parseModelConfig("bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0");
+      expect(result.provider).toBe("bedrock");
+      expect(result.modelName).toBe("anthropic.claude-3-5-sonnet-20241022-v2:0");
+      expect(result.envSuffix).toBeUndefined();
+      expect(result.envVar).toBeUndefined();
+    });
+
+    it("handles cross-region inference profile IDs", () => {
+      const result = parseModelConfig("bedrock:us.anthropic.claude-sonnet-4-5-20250929-v1:0");
+      expect(result.provider).toBe("bedrock");
+      expect(result.modelName).toBe("us.anthropic.claude-sonnet-4-5-20250929-v1:0");
+    });
+
+    it("handles non-Anthropic Bedrock model IDs", () => {
+      const result = parseModelConfig("bedrock:meta.llama3-70b-instruct-v1:0");
+      expect(result.provider).toBe("bedrock");
+      expect(result.modelName).toBe("meta.llama3-70b-instruct-v1:0");
+    });
+
+    it("does not extract env suffix even with _KEY in remainder", () => {
+      const result = parseModelConfig("bedrock:my.model:AWS_BEARER_TOKEN_BEDROCK");
+      expect(result.provider).toBe("bedrock");
+      expect(result.modelName).toBe("my.model:AWS_BEARER_TOKEN_BEDROCK");
+      expect(result.envVar).toBeUndefined();
+      expect(result.envSuffix).toBeUndefined();
+    });
+  });
 });

--- a/tests/provider-command.test.ts
+++ b/tests/provider-command.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, spyOn } from 'bun:test';
+import { createProviderCommand } from '../src/cli/auth';
+import { logger } from '../src/utils/logger';
+
+describe('createProviderCommand', () => {
+  let errorSpy: ReturnType<typeof spyOn> | undefined;
+  let exitSpy: ReturnType<typeof spyOn> | undefined;
+
+  afterEach(() => {
+    errorSpy?.mockRestore();
+    exitSpy?.mockRestore();
+  });
+
+  it('rejects bedrock as a reserved custom provider name', async () => {
+    const command = createProviderCommand();
+    errorSpy = spyOn(logger, 'error').mockImplementation(() => {});
+    exitSpy = spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit:1');
+    }) as any);
+
+    await expect(
+      command.parseAsync(['add', 'bedrock', '--url', 'http://localhost:11434/v1'], { from: 'user' })
+    ).rejects.toThrow('process.exit:1');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Cannot use reserved provider name 'bedrock'. Reserved: anthropic, openai, openrouter, demo, bedrock"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds support for [Amazon Bedrock](https://ai-sdk.dev/providers/ai-sdk-providers/amazon-bedrock) as a first-class provider, using the official `@ai-sdk/amazon-bedrock` package.

## Changes

- **`src/models.ts`**
  - Import `createAmazonBedrock` from `@ai-sdk/amazon-bedrock`.
  - Add an early-return in `parseModelConfig` for `bedrock:` so the rest of the string (which contains colons, e.g. `anthropic.claude-3-5-sonnet-20241022-v2:0`) is preserved as the model ID. Env-suffix syntax is intentionally not supported for Bedrock.
  - Add a `bedrock` branch in `createModel` that supports both:
    - **AWS SigV4**: `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` + `AWS_REGION` (+ optional `AWS_SESSION_TOKEN`)
    - **Bearer token**: `AWS_BEARER_TOKEN_BEDROCK`
- **`src/utils/model-utils.ts`** — skip the static model registry validation for `bedrock:` (model IDs are AWS-specific and not in models.dev).
- **`src/cli/auth.ts`** — mention Bedrock env vars and IAM setup in `agentuse provider help`.
- **`package.json`** — add `@ai-sdk/amazon-bedrock` dependency.

## Usage

```bash
export AWS_REGION=us-east-1
export AWS_ACCESS_KEY_ID=...
export AWS_SECRET_ACCESS_KEY=...

agentuse run agent.md --model bedrock:us.anthropic.claude-sonnet-4-5-20250929-v1:0
```

Or with a Bedrock API key:
```bash
export AWS_REGION=us-east-1
export AWS_BEARER_TOKEN_BEDROCK=...
agentuse run agent.md --model bedrock:meta.llama3-70b-instruct-v1:0
```

## Notes / Follow-ups

- Bedrock model IDs are not added to the generated `src/generated/models.ts` registry; validation is skipped for the `bedrock:` prefix. If desired, `scripts/generate-models.ts` could later be extended to include Bedrock entries from models.dev.
- No new tests were added — `parseModelConfig` behavior was verified manually for representative Bedrock IDs and existing providers were not affected.
