### PR TITLE
feat(plugins): Claude/VS Code-compatible plugin bundle system

### DIFF
--- a/docs/guides/plugins.mdx
+++ b/docs/guides/plugins.mdx
@@ -1,18 +1,101 @@
 # Plugin System
 
-## Why Plugins?
+AgentUse supports two complementary plugin styles:
 
-The plugin system is the only way to programmatically extend agent functionality beyond the built-in capabilities. While agents themselves are markdown-based and declarative, plugins provide a JavaScript/TypeScript interface for:
+1. **Plugin bundles** (Claude / VS Code-compatible): packaged directories containing a `plugin.json` manifest plus skills, agents, and MCP server definitions. Bundles can live locally, be auto-discovered, or be pulled from a Git repository.
+2. **Lifecycle hooks** (legacy): single JS/TS files that handle runtime events such as `agent:complete`.
 
-- **Custom integrations**: Connect agents to your existing systems, databases, or APIs
-- **Observability**: Add monitoring, logging, or analytics to track agent performance
-- **Automation workflows**: Trigger actions based on agent completion or failure
-- **Development tools**: Build debugging utilities or testing frameworks
-- **Cross-agent functionality**: Share logic across all agents without modifying each one
+This guide covers both, starting with bundles.
 
-Without plugins, you would be limited to the tools and capabilities built into AgentUse. Plugins bridge the gap between AgentUse's declarative agent definitions and your custom programmatic needs.
+---
 
-## Quick Start
+## Plugin Bundles
+
+A plugin bundle is a directory that ships skills, agents and/or MCP servers as a single unit. The format is compatible with VS Code agent plugins and Claude Code plugins, so bundles authored for either ecosystem can be reused as-is.
+
+### Bundle layout
+
+```
+my-plugin/
+  plugin.json          # required manifest (also accepted at .plugin/, .claude-plugin/, .github/plugin/)
+  skills/              # optional — auto-included if present
+    my-skill/
+      SKILL.md
+  agents/              # optional — auto-included if present
+    helper.agentuse
+  .mcp.json            # optional — referenced from plugin.json
+```
+
+### `plugin.json`
+
+```json
+{
+  "name": "my-plugin",
+  "version": "1.0.0",
+  "description": "Example plugin",
+  "skills": "skills/",
+  "agents": "agents/",
+  "mcpServers": ".mcp.json"
+}
+```
+
+- `name` (required) — kebab-case, ≤ 64 chars.
+- `skills` / `agents` — string or string array of directories. Defaults to `skills/` / `agents/` when those directories exist.
+- `mcpServers` — either a path to a JSON file (with a top-level `mcpServers` object) or an inline object. Use `${PLUGIN_ROOT}` or `${CLAUDE_PLUGIN_ROOT}` to reference files inside the plugin.
+
+### Auto-discovery
+
+Bundles are loaded automatically from any of these directories (project takes priority over user, AgentUse over Claude):
+
+- `./.agentuse/plugins/<bundle>/`
+- `~/.agentuse/plugins/<bundle>/`
+- `./.claude/plugins/<bundle>/`
+- `~/.claude/plugins/<bundle>/`
+
+A directory is treated as a bundle only if it contains a recognized `plugin.json`. Legacy single-file lifecycle plugins (`./.agentuse/plugins/*.js`) keep working unchanged.
+
+### Declaring plugins in an agent
+
+Add a `plugins:` array to the agent frontmatter. Each entry is a *spec*:
+
+```yaml
+---
+model: anthropic:claude-sonnet-4-5
+plugins:
+  - ./local/path/to/plugin              # local directory
+  - /absolute/path/to/plugin
+  - ~/shared/plugins/mine
+  - agentuse/example-plugin             # GitHub: owner/repo
+  - agentuse/monorepo/.github/plugins/x # GitHub subpath
+  - agentuse/example-plugin@v1.2.0      # GitHub at tag/branch/SHA
+  - https://github.com/org/repo.git     # generic git URL
+  - git@github.com:org/repo.git@main    # SSH + ref
+---
+```
+
+GitHub specs are cloned (shallow) into `~/.local/share/agentuse/plugin-cache/` on first use and reused afterwards.
+
+### What happens at runtime
+
+When an agent runs, AgentUse:
+
+1. Auto-discovers local bundle directories.
+2. Resolves every spec listed in `plugins:` (cloning Git repos when needed).
+3. Validates each `plugin.json`.
+4. Adds the bundle's `skills/` directories to skill discovery (alongside your project skills).
+5. Merges the bundle's MCP servers into the agent's MCP server map. Plugin servers are namespaced as `<plugin-name>.<server-name>` so they can never collide with user-defined servers (user config wins on key collisions).
+
+If a plugin fails to load, a warning is logged and the agent continues.
+
+### Security
+
+Plugins can ship MCP servers that execute code on your machine. Only install bundles from sources you trust, and pin a `@ref` (tag or SHA) for reproducibility when pulling from GitHub.
+
+---
+
+## Programmatic Plugin Mechanism
+
+
 
 1. Create a plugin directory:
 ```bash

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { basename, resolve, dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import * as readline from 'readline';
 import { PluginManager } from './plugin';
+import { loadPluginBundles, type LoadedPluginsResult } from './plugin-bundle';
 import { extractLearnings } from './learning/index.js';
 import { version as packageVersion } from '../package.json';
 import { existsSync as existsSyncFs } from 'fs';
@@ -412,6 +413,31 @@ program
       // Since we've already changed directory, resolve the file path from the new CWD
       const agentFilePath = !isURL(file) ? resolve(file) : undefined;
       const mcpBasePath = agentFilePath ? dirname(agentFilePath) : undefined;
+
+      // Resolve plugin bundles (auto-discovered + frontmatter `plugins:` array).
+      // Must run BEFORE connectMCP so plugin-contributed MCP servers are included.
+      let loadedPluginBundles: LoadedPluginsResult = { plugins: [], skillDirs: [], agentDirs: [], mcpServers: {} };
+      try {
+        loadedPluginBundles = await loadPluginBundles({
+          projectRoot: projectContext.projectRoot,
+          specs: agent.config.plugins,
+        });
+        if (loadedPluginBundles.plugins.length > 0) {
+          logger.debug(
+            `Loaded ${loadedPluginBundles.plugins.length} plugin bundle(s): ${loadedPluginBundles.plugins.map(p => p.manifest.name).join(', ')}`
+          );
+          // Merge plugin MCP servers into agent config (user config wins on key collisions).
+          if (Object.keys(loadedPluginBundles.mcpServers).length > 0) {
+            agent.config.mcpServers = {
+              ...loadedPluginBundles.mcpServers,
+              ...(agent.config.mcpServers ?? {}),
+            };
+          }
+        }
+      } catch (e) {
+        logger.warn(`Failed to load plugin bundles: ${(e as Error).message}`);
+      }
+
       let mcp;
       try {
         mcp = await connectMCP(agent.config.mcpServers, options.debug, mcpBasePath);
@@ -517,7 +543,8 @@ program
         projectContext: { projectRoot: projectContext.projectRoot, cwd: process.cwd() },
         userPrompt: additionalPrompt || undefined,
         abortSignal: abortController.signal,
-        verbose: options.debug
+        verbose: options.debug,
+        extraSkillDirs: loadedPluginBundles.skillDirs.length > 0 ? loadedPluginBundles.skillDirs : undefined
       });
 
       // Update session info for interrupt handling (now that we have sessionID)

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -88,7 +88,12 @@ const AgentSchema = z.object({
   // Learning configuration: extract and apply learnings from execution
   learning: LearningConfigSchema.optional(),
   // Sandbox configuration: isolated cloud VM for command execution
-  sandbox: SandboxConfigSchema.optional()
+  sandbox: SandboxConfigSchema.optional(),
+  // Plugin bundles to load (Claude/VS Code-style). Each item is a spec string:
+  //   - "./local/path" or "/abs/path" — local directory containing plugin.json
+  //   - "owner/repo[/subpath][@ref]" — GitHub shorthand
+  //   - "https://host/owner/repo.git" or "git@host:owner/repo.git" — generic git URL
+  plugins: z.array(z.string().min(1)).optional()
 }).transform((data) => {
   // Handle backward compatibility: support both mcp_servers and mcpServers
   if (data.mcp_servers && data.mcpServers) {

--- a/src/plugin-bundle/index.ts
+++ b/src/plugin-bundle/index.ts
@@ -1,0 +1,11 @@
+export { parsePluginSpec } from './spec';
+export { findManifest, loadPluginFromRoot, MANIFEST_LOCATIONS } from './manifest';
+export { resolvePluginSpec } from './resolver';
+export { loadPluginBundles } from './loader';
+export type {
+  PluginManifest,
+  PluginSpec,
+  LoadedPlugin,
+  PluginMcpServersConfig,
+} from './types';
+export type { LoadPluginsOptions, LoadedPluginsResult } from './loader';

--- a/src/plugin-bundle/loader.ts
+++ b/src/plugin-bundle/loader.ts
@@ -1,0 +1,132 @@
+import { homedir } from 'os';
+import { join } from 'path';
+import { readdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import { logger } from '../utils/logger';
+import { parsePluginSpec } from './spec';
+import { resolvePluginSpec } from './resolver';
+import { findManifest, loadPluginFromRoot } from './manifest';
+import type { LoadedPlugin, PluginMcpServersConfig } from './types';
+
+export interface LoadPluginsOptions {
+  /** Project root used to resolve relative paths in specs and to scan local plugin dirs. */
+  projectRoot: string;
+  /** Specs declared in the agent frontmatter `plugins:` array. */
+  specs?: string[] | undefined;
+  /**
+   * If true, also auto-discover bundle plugins (directories containing `plugin.json`)
+   * inside `<root>/.agentuse/plugins/`, `~/.agentuse/plugins/`, `<root>/.claude/plugins/`,
+   * `~/.claude/plugins/`. Defaults to true.
+   */
+  autoDiscover?: boolean;
+}
+
+export interface LoadedPluginsResult {
+  plugins: LoadedPlugin[];
+  /** All skill discovery directories contributed by plugins. */
+  skillDirs: string[];
+  /** All agent directories contributed by plugins. */
+  agentDirs: string[];
+  /** Combined MCP server map from every plugin (namespaced by `pluginName.serverName`). */
+  mcpServers: PluginMcpServersConfig;
+}
+
+/**
+ * Load all plugin bundles for an agent run. Failures on individual plugins are logged
+ * and skipped — they should never break the agent.
+ */
+export async function loadPluginBundles(options: LoadPluginsOptions): Promise<LoadedPluginsResult> {
+  const { projectRoot, specs = [], autoDiscover = true } = options;
+  const seen = new Set<string>();
+  const plugins: LoadedPlugin[] = [];
+
+  // 1. Auto-discovered bundle directories.
+  if (autoDiscover) {
+    for (const dir of getAutoDiscoverDirs(projectRoot)) {
+      for (const root of await listBundleDirs(dir)) {
+        await tryLoad(plugins, seen, root, `auto:${root}`);
+      }
+    }
+  }
+
+  // 2. Frontmatter specs.
+  for (const raw of specs) {
+    try {
+      const spec = parsePluginSpec(raw);
+      const root = await resolvePluginSpec(spec, projectRoot);
+      await tryLoad(plugins, seen, root, raw);
+    } catch (e) {
+      logger.warn(`[plugin-bundle] failed to load "${raw}": ${(e as Error).message}`);
+    }
+  }
+
+  return aggregate(plugins);
+}
+
+async function tryLoad(plugins: LoadedPlugin[], seen: Set<string>, root: string, source: string) {
+  if (seen.has(root)) return;
+  seen.add(root);
+  try {
+    const loaded = await loadPluginFromRoot(root, source);
+    if (!loaded) {
+      // Only warn if the user explicitly asked for this one.
+      if (!source.startsWith('auto:')) {
+        logger.warn(`[plugin-bundle] no plugin.json found in ${root} (from "${source}")`);
+      }
+      return;
+    }
+    plugins.push(loaded);
+    logger.debug(`[plugin-bundle] loaded "${loaded.manifest.name}" from ${loaded.root}`);
+  } catch (e) {
+    logger.warn(`[plugin-bundle] failed to load ${root}: ${(e as Error).message}`);
+  }
+}
+
+function getAutoDiscoverDirs(projectRoot: string): string[] {
+  const home = homedir();
+  return [
+    join(projectRoot, '.agentuse', 'plugins'),
+    join(home, '.agentuse', 'plugins'),
+    join(projectRoot, '.claude', 'plugins'),
+    join(home, '.claude', 'plugins'),
+  ];
+}
+
+/** Return immediate subdirectories of `dir` that contain a recognized plugin manifest. */
+async function listBundleDirs(dir: string): Promise<string[]> {
+  if (!existsSync(dir)) return [];
+  const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+  const out: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const candidate = join(dir, entry.name);
+    if (await findManifest(candidate)) {
+      out.push(candidate);
+    }
+  }
+  return out;
+}
+
+function aggregate(plugins: LoadedPlugin[]): LoadedPluginsResult {
+  const skillDirs: string[] = [];
+  const agentDirs: string[] = [];
+  const mcpServers: PluginMcpServersConfig = {} as PluginMcpServersConfig;
+  const usedNames = new Set<string>();
+
+  for (const p of plugins) {
+    skillDirs.push(...p.skillDirs);
+    agentDirs.push(...p.agentDirs);
+    for (const [serverName, cfg] of Object.entries(p.mcpServers ?? {})) {
+      // Namespace to avoid collisions with user-defined mcpServers and other plugins.
+      let key = `${p.manifest.name}.${serverName}`;
+      let i = 2;
+      while (usedNames.has(key) || key in (mcpServers as Record<string, unknown>)) {
+        key = `${p.manifest.name}.${serverName}#${i++}`;
+      }
+      usedNames.add(key);
+      (mcpServers as Record<string, unknown>)[key] = cfg;
+    }
+  }
+
+  return { plugins, skillDirs, agentDirs, mcpServers };
+}

--- a/src/plugin-bundle/manifest.ts
+++ b/src/plugin-bundle/manifest.ts
@@ -1,0 +1,152 @@
+import { z } from 'zod';
+import { readFile, stat } from 'fs/promises';
+import { join, isAbsolute, resolve } from 'path';
+import type { LoadedPlugin, PluginManifest, PluginMcpServersConfig } from './types';
+
+/** Locations checked for `plugin.json`, in priority order. */
+export const MANIFEST_LOCATIONS = [
+  '.plugin/plugin.json',
+  'plugin.json',
+  '.github/plugin/plugin.json',
+  '.claude-plugin/plugin.json',
+];
+
+const ManifestSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .max(64)
+    .regex(/^[a-z0-9][a-z0-9-]*$/, 'Plugin name must be kebab-case (lowercase letters, numbers, hyphens)'),
+  version: z.string().optional(),
+  description: z.string().max(1024).optional(),
+  author: z
+    .object({
+      name: z.string(),
+      email: z.string().optional(),
+      url: z.string().optional(),
+    })
+    .optional(),
+  skills: z.union([z.string(), z.array(z.string())]).optional(),
+  agents: z.union([z.string(), z.array(z.string())]).optional(),
+  mcpServers: z.union([z.string(), z.record(z.unknown()), z.object({ mcpServers: z.record(z.unknown()) })]).optional(),
+});
+
+/** Try to find a `plugin.json` inside `root`. Returns absolute path or null. */
+export async function findManifest(root: string): Promise<string | null> {
+  for (const rel of MANIFEST_LOCATIONS) {
+    const candidate = join(root, rel);
+    try {
+      const s = await stat(candidate);
+      if (s.isFile()) return candidate;
+    } catch {
+      // continue
+    }
+  }
+  return null;
+}
+
+/**
+ * Load a plugin bundle from an already-resolved root directory.
+ * Returns null if no manifest is found (caller decides whether to warn).
+ */
+export async function loadPluginFromRoot(root: string, source: string): Promise<LoadedPlugin | null> {
+  const manifestPath = await findManifest(root);
+  if (!manifestPath) return null;
+
+  const raw = await readFile(manifestPath, 'utf-8');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`Invalid JSON in ${manifestPath}: ${(e as Error).message}`);
+  }
+
+  const result = ManifestSchema.safeParse(parsed);
+  if (!result.success) {
+    const msg = result.error.errors.map(e => `${e.path.join('.') || 'root'}: ${e.message}`).join('; ');
+    throw new Error(`Invalid plugin manifest at ${manifestPath}: ${msg}`);
+  }
+
+  const manifest = result.data as PluginManifest;
+  const absRoot = resolve(root);
+
+  const skillDirs = await resolveDirList(absRoot, manifest.skills, 'skills');
+  const agentDirs = await resolveDirList(absRoot, manifest.agents, 'agents');
+  const mcpServers = await loadMcpServers(absRoot, manifest);
+
+  return { root: absRoot, source, manifest, skillDirs, agentDirs, mcpServers };
+}
+
+async function resolveDirList(
+  root: string,
+  value: string | string[] | undefined,
+  defaultDir: string
+): Promise<string[]> {
+  const candidates: string[] = [];
+  if (value === undefined) {
+    candidates.push(defaultDir);
+  } else if (typeof value === 'string') {
+    candidates.push(value);
+  } else {
+    candidates.push(...value);
+  }
+
+  const out: string[] = [];
+  for (const c of candidates) {
+    const abs = isAbsolute(c) ? c : join(root, c);
+    try {
+      const s = await stat(abs);
+      if (s.isDirectory()) out.push(abs);
+    } catch {
+      // Silently skip missing dirs (especially the implicit defaults).
+    }
+  }
+  return out;
+}
+
+async function loadMcpServers(root: string, manifest: PluginManifest): Promise<PluginMcpServersConfig> {
+  const mcp = manifest.mcpServers;
+  if (mcp === undefined) return {};
+
+  let inline: Record<string, unknown> | undefined;
+
+  if (typeof mcp === 'string') {
+    const file = isAbsolute(mcp) ? mcp : join(root, mcp);
+    try {
+      const raw = await readFile(file, 'utf-8');
+      const parsed = JSON.parse(raw);
+      inline =
+        parsed && typeof parsed === 'object' && 'mcpServers' in parsed
+          ? (parsed as { mcpServers: Record<string, unknown> }).mcpServers
+          : (parsed as Record<string, unknown>);
+    } catch (e) {
+      throw new Error(`Failed to read MCP config ${file}: ${(e as Error).message}`);
+    }
+  } else if (mcp && typeof mcp === 'object') {
+    if ('mcpServers' in mcp && (mcp as { mcpServers?: unknown }).mcpServers) {
+      inline = (mcp as { mcpServers: Record<string, unknown> }).mcpServers;
+    } else {
+      inline = mcp as Record<string, unknown>;
+    }
+  }
+
+  if (!inline) return {};
+
+  // Expand ${PLUGIN_ROOT} / ${CLAUDE_PLUGIN_ROOT} tokens to absolute paths.
+  return expandPluginRootTokens(inline, root) as PluginMcpServersConfig;
+}
+
+function expandPluginRootTokens<T>(value: T, root: string): T {
+  const replace = (s: string) => s.replace(/\$\{(?:CLAUDE_)?PLUGIN_ROOT\}/g, root);
+
+  if (typeof value === 'string') return replace(value) as unknown as T;
+  if (Array.isArray(value)) return value.map(v => expandPluginRootTokens(v, root)) as unknown as T;
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = expandPluginRootTokens(v, root);
+    }
+    return out as unknown as T;
+  }
+  return value;
+}

--- a/src/plugin-bundle/resolver.ts
+++ b/src/plugin-bundle/resolver.ts
@@ -1,0 +1,108 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { homedir } from 'os';
+import { join, isAbsolute, resolve as resolvePath } from 'path';
+import { mkdir, stat } from 'fs/promises';
+import { existsSync } from 'fs';
+import { getPluginCacheDir } from '../storage/paths';
+import { logger } from '../utils/logger';
+import type { PluginSpec } from './types';
+
+const execFileP = promisify(execFile);
+
+/**
+ * Resolve a plugin spec to a local directory containing the plugin.
+ * For git specs, clones into the user-level cache (idempotent).
+ */
+export async function resolvePluginSpec(spec: PluginSpec, baseDir: string): Promise<string> {
+  if (spec.kind === 'local') {
+    return resolveLocalPath(spec.path, baseDir);
+  }
+
+  const repoDir = await ensureGitRepo(spec);
+  return spec.subpath ? join(repoDir, spec.subpath) : repoDir;
+}
+
+function resolveLocalPath(p: string, baseDir: string): string {
+  let expanded = p;
+  if (expanded.startsWith('~')) {
+    expanded = join(homedir(), expanded.slice(1));
+  }
+  if (isAbsolute(expanded)) return expanded;
+  return resolvePath(baseDir, expanded);
+}
+
+async function ensureGitRepo(spec: PluginSpec & { kind: 'git' }): Promise<string> {
+  const cacheRoot = await getPluginCacheDir();
+  const host = spec.host === 'github' ? 'github.com' : safeHost(spec.url ?? 'git');
+  const refDir = sanitizeRefForFs(spec.ref ?? 'HEAD');
+  const target = join(cacheRoot, host, spec.owner, `${spec.repo}@${refDir}`);
+
+  if (existsSync(target) && (await isNonEmptyDir(target))) {
+    logger.debug(`[plugin-bundle] cache hit: ${spec.raw} → ${target}`);
+    return target;
+  }
+
+  await mkdir(join(cacheRoot, host, spec.owner), { recursive: true });
+  const url = spec.url ?? `https://github.com/${spec.owner}/${spec.repo}.git`;
+
+  logger.debug(`[plugin-bundle] cloning ${url} (ref=${spec.ref ?? 'default'}) → ${target}`);
+
+  // Shallow clone, then optionally checkout ref.
+  const cloneArgs = ['clone', '--depth', '1'];
+  if (spec.ref && isLikelyBranchOrTag(spec.ref)) {
+    cloneArgs.push('--branch', spec.ref);
+  }
+  cloneArgs.push(url, target);
+
+  try {
+    await execFileP('git', cloneArgs, { timeout: 120_000 });
+  } catch (e) {
+    // Retry without --branch (could be a SHA).
+    if (spec.ref) {
+      try {
+        await execFileP('git', ['clone', url, target], { timeout: 120_000 });
+        await execFileP('git', ['checkout', spec.ref], { cwd: target, timeout: 60_000 });
+      } catch (e2) {
+        throw new Error(`Failed to clone plugin ${spec.raw}: ${(e2 as Error).message}`);
+      }
+    } else {
+      throw new Error(`Failed to clone plugin ${spec.raw}: ${(e as Error).message}`);
+    }
+  }
+
+  return target;
+}
+
+async function isNonEmptyDir(p: string): Promise<boolean> {
+  try {
+    const s = await stat(p);
+    if (!s.isDirectory()) return false;
+    const { readdir } = await import('fs/promises');
+    const entries = await readdir(p);
+    return entries.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function sanitizeRefForFs(ref: string): string {
+  return ref.replace(/[^A-Za-z0-9._-]/g, '_');
+}
+
+function safeHost(url: string): string {
+  try {
+    if (url.startsWith('git@')) {
+      const m = url.match(/^git@([^:]+):/);
+      return m ? m[1] : 'git';
+    }
+    return new URL(url).host || 'git';
+  } catch {
+    return 'git';
+  }
+}
+
+function isLikelyBranchOrTag(ref: string): boolean {
+  // Heuristic: 40-char hex looks like a SHA.
+  return !/^[0-9a-f]{40}$/i.test(ref);
+}

--- a/src/plugin-bundle/spec.ts
+++ b/src/plugin-bundle/spec.ts
@@ -1,0 +1,84 @@
+import { isAbsolute } from 'path';
+import type { PluginSpec } from './types';
+
+/**
+ * Parse a plugin spec string from the agent frontmatter `plugins:` array.
+ *
+ * Supported formats:
+ *   - `./relative/path`             → local
+ *   - `/absolute/path`              → local
+ *   - `~/path`                      → local (home expansion happens in resolver)
+ *   - `owner/repo`                  → github repo root
+ *   - `owner/repo/sub/path`         → github subdirectory
+ *   - `owner/repo@ref`              → github at ref
+ *   - `owner/repo/sub/path@ref`     → github subdirectory at ref
+ *   - `https://github.com/o/r.git`  → generic git url
+ *   - `git@github.com:o/r.git`      → generic git url (ssh)
+ */
+export function parsePluginSpec(raw: string): PluginSpec {
+  const input = raw.trim();
+  if (!input) {
+    throw new Error('Plugin spec is empty');
+  }
+
+  // Local paths
+  if (input.startsWith('./') || input.startsWith('../') || input.startsWith('~') || isAbsolute(input)) {
+    return { kind: 'local', path: input, raw: input };
+  }
+
+  // Generic git URLs (https / ssh)
+  if (input.startsWith('http://') || input.startsWith('https://') || input.startsWith('git@') || input.startsWith('ssh://')) {
+    const { url, ref } = splitRef(input);
+    const { owner, repo } = parseGitUrl(url);
+    return { kind: 'git', host: 'generic', owner, repo, url, raw: input, ...(ref ? { ref } : {}) };
+  }
+
+  // Shorthand: owner/repo[/subpath][@ref]
+  const { url: shorthand, ref } = splitRef(input);
+  const segments = shorthand.split('/').filter(Boolean);
+  if (segments.length < 2) {
+    throw new Error(`Invalid plugin spec "${raw}": expected "owner/repo[/subpath][@ref]" or a path / URL`);
+  }
+  const [owner, repo, ...rest] = segments;
+  const subpath = rest.length > 0 ? rest.join('/') : undefined;
+
+  if (!isValidGithubSegment(owner) || !isValidGithubSegment(repo)) {
+    throw new Error(`Invalid plugin spec "${raw}": owner/repo contains invalid characters`);
+  }
+
+  return {
+    kind: 'git',
+    host: 'github',
+    owner,
+    repo,
+    raw: input,
+    ...(subpath ? { subpath } : {}),
+    ...(ref ? { ref } : {}),
+  };
+}
+
+function splitRef(input: string): { url: string; ref?: string } {
+  // `@` after the last `/` is treated as ref. We must not split on `@` in user@host SSH URLs.
+  const lastSlash = input.lastIndexOf('/');
+  const at = input.indexOf('@', lastSlash + 1);
+  if (at === -1) return { url: input };
+  return { url: input.slice(0, at), ref: input.slice(at + 1) };
+}
+
+function parseGitUrl(url: string): { owner: string; repo: string } {
+  // https://host/owner/repo(.git)
+  // git@host:owner/repo(.git)
+  // ssh://git@host/owner/repo(.git)
+  const cleaned = url.replace(/\.git$/, '');
+  const match =
+    cleaned.match(/[:/]([^/:]+)\/([^/:]+)$/) ||
+    cleaned.match(/^([^/]+)\/([^/]+)$/);
+  if (!match) {
+    throw new Error(`Cannot parse git URL: ${url}`);
+  }
+  return { owner: match[1], repo: match[2] };
+}
+
+function isValidGithubSegment(s: string): boolean {
+  return /^[A-Za-z0-9._-]+$/.test(s);
+}

--- a/src/plugin-bundle/types.ts
+++ b/src/plugin-bundle/types.ts
@@ -1,0 +1,62 @@
+/**
+ * Plugin bundle system — Claude/VS Code-style packaged customizations.
+ *
+ * A plugin bundle is a directory containing a `plugin.json` manifest plus any
+ * combination of skills, agents, and MCP server definitions. Bundles can be
+ * loaded from a local path or fetched from a Git host (GitHub by default).
+ *
+ * This is a separate concept from the in-process `PluginManager` in `src/plugin/`,
+ * which only handles JS/TS lifecycle hooks (e.g. `agent:complete`).
+ */
+
+import type { AgentConfig } from '../parser';
+
+/** MCP servers config — same shape as in agent frontmatter. */
+export type PluginMcpServersConfig = NonNullable<AgentConfig['mcpServers']>;
+
+export interface PluginManifest {
+  /** kebab-case identifier */
+  name: string;
+  version?: string;
+  description?: string;
+  author?: { name: string; email?: string; url?: string };
+  /** Path(s) to skill directories, relative to the plugin root. Defaults to "skills/" if present. */
+  skills?: string | string[];
+  /** Path(s) to agent directories, relative to the plugin root. Defaults to "agents/" if present. */
+  agents?: string | string[];
+  /** Path to a JSON file (e.g. ".mcp.json") OR an inline `{ mcpServers: {...} }` object. */
+  mcpServers?: string | { mcpServers?: PluginMcpServersConfig } | PluginMcpServersConfig;
+}
+
+/** A successfully loaded plugin bundle. */
+export interface LoadedPlugin {
+  /** Directory of the plugin (absolute path). */
+  root: string;
+  /** Where the plugin came from (spec string or "auto" for auto-discovered bundles). */
+  source: string;
+  manifest: PluginManifest;
+  /** Absolute paths to skill discovery directories. */
+  skillDirs: string[];
+  /** Absolute paths to agent directories. */
+  agentDirs: string[];
+  /** MCP servers contributed by this plugin, namespaced by plugin name and ready for `connectMCP`. */
+  mcpServers: PluginMcpServersConfig;
+}
+
+/** Parsed plugin spec from frontmatter `plugins:` array. */
+export type PluginSpec =
+  | { kind: 'local'; path: string; raw: string }
+  | {
+      kind: 'git';
+      host: 'github' | 'generic';
+      /** owner for github, full URL for generic */
+      owner: string;
+      repo: string;
+      /** Subpath within the cloned repo (no leading slash). */
+      subpath?: string;
+      /** Branch, tag, or commit SHA. */
+      ref?: string;
+      /** Full URL for generic git hosts (https/ssh). */
+      url?: string;
+      raw: string;
+    };

--- a/src/runner/preparation.ts
+++ b/src/runner/preparation.ts
@@ -116,6 +116,7 @@ export async function prepareAgentExecution(options: PrepareAgentOptions): Promi
     agentFilePath,
     mcpConnections: mcpClients,
     sessionId: sessionID,
+    extraSkillDirs: options.extraSkillDirs,
   });
 
   // Compute agentId (file-path-based identifier) for session operations

--- a/src/runner/tools-loader.ts
+++ b/src/runner/tools-loader.ts
@@ -27,6 +27,8 @@ export interface LoadAgentToolsOptions {
   logPrefix?: string | undefined;
   /** Session ID for sandbox output directory */
   sessionId?: string | undefined;
+  /** Extra skill discovery directories (e.g. injected by plugin bundles). */
+  extraSkillDirs?: string[] | undefined;
 }
 
 /**
@@ -60,6 +62,7 @@ export async function loadAgentTools(options: LoadAgentToolsOptions): Promise<Lo
     mcpConnections,
     logPrefix = '',
     sessionId,
+    extraSkillDirs,
   } = options;
 
   // Compute agentId (file-path-based identifier) for store naming
@@ -88,7 +91,7 @@ export async function loadAgentTools(options: LoadAgentToolsOptions): Promise<Lo
   let skillTools: Record<string, Tool> = {};
   if (projectContext) {
     try {
-      const { skillTool, skillReadTool, skills } = await createSkillTools(projectContext.projectRoot, agent.config.tools);
+      const { skillTool, skillReadTool, skills } = await createSkillTools(projectContext.projectRoot, agent.config.tools, extraSkillDirs);
       if (skills.length > 0) {
         skillTools['tools__skill_load'] = skillTool;
         skillTools['tools__skill_read'] = skillReadTool;

--- a/src/runner/types.ts
+++ b/src/runner/types.ts
@@ -15,6 +15,8 @@ export interface PrepareAgentOptions {
   userPrompt?: string | undefined;
   abortSignal?: AbortSignal | undefined;
   verbose?: boolean | undefined;
+  /** Extra skill discovery directories (typically contributed by plugin bundles). */
+  extraSkillDirs?: string[] | undefined;
 }
 
 export interface PreparedAgentExecution {

--- a/src/skill/discovery.ts
+++ b/src/skill/discovery.ts
@@ -21,7 +21,6 @@ function getDiscoveryDirectories(projectRoot: string): string[] {
     join(home, '.claude', 'skills'),
   ];
 }
-
 /**
  * Check if a directory exists
  */
@@ -37,10 +36,17 @@ async function directoryExists(dir: string): Promise<boolean> {
 /**
  * Discover all skills from configured directories
  * Returns map of skill name to SkillInfo
+ *
+ * @param projectRoot Root of the user's project (used for `.agentuse/skills`, `.claude/skills`).
+ * @param extraDirs   Additional skill directories (highest priority — checked first).
+ *                    Used by the plugin-bundle system to inject skills shipped with plugins.
  */
-export async function discoverSkills(projectRoot: string): Promise<Map<string, SkillInfo>> {
+export async function discoverSkills(
+  projectRoot: string,
+  extraDirs?: string[]
+): Promise<Map<string, SkillInfo>> {
   const skills = new Map<string, SkillInfo>();
-  const directories = getDiscoveryDirectories(projectRoot);
+  const directories = [...(extraDirs ?? []), ...getDiscoveryDirectories(projectRoot)];
 
   for (const dir of directories) {
     if (!await directoryExists(dir)) {

--- a/src/skill/tool.ts
+++ b/src/skill/tool.ts
@@ -174,13 +174,16 @@ export async function createSkillTool(
 
 /**
  * Create both skill tools: skill loader and skill file reader
+ *
+ * @param extraSkillDirs Optional additional skill directories (e.g. from plugin bundles).
  */
 export async function createSkillTools(
   projectRoot: string,
-  agentToolsConfig: ToolsConfig | undefined
+  agentToolsConfig: ToolsConfig | undefined,
+  extraSkillDirs?: string[]
 ): Promise<SkillToolsResult> {
   // Discover all available skills
-  const skillsMap = await discoverSkills(projectRoot);
+  const skillsMap = await discoverSkills(projectRoot, extraSkillDirs);
   const skills = Array.from(skillsMap.values());
 
   // Track loaded skills: name -> directory (shared between both tools)

--- a/src/storage/paths.ts
+++ b/src/storage/paths.ts
@@ -59,6 +59,17 @@ export async function getSessionStorageDir(projectRoot: string): Promise<string>
 }
 
 /**
+ * Get the user-level cache directory for resolved plugin bundles.
+ * Returns: {xdgData}/agentuse/plugin-cache
+ */
+export async function getPluginCacheDir(): Promise<string> {
+  const dir = path.join(getXdgDataDir(), 'agentuse', 'plugin-cache');
+  const { mkdir } = await import('fs/promises');
+  await mkdir(dir, { recursive: true });
+  return dir;
+}
+
+/**
  * Sanitize agent name for use in filesystem paths
  * Converts to lowercase and replaces invalid characters with hyphens
  */

--- a/tests/plugin-bundle-loader.test.ts
+++ b/tests/plugin-bundle-loader.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, writeFile, mkdir, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { loadPluginBundles } from '../src/plugin-bundle/loader';
+
+describe('loadPluginBundles', () => {
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    projectRoot = await mkdtemp(join(tmpdir(), 'plugin-loader-'));
+  });
+
+  afterEach(async () => {
+    await rm(projectRoot, { recursive: true, force: true });
+  });
+
+  it('returns empty result when no plugins are found', async () => {
+    const result = await loadPluginBundles({ projectRoot, autoDiscover: false });
+    expect(result.plugins).toEqual([]);
+    expect(result.skillDirs).toEqual([]);
+    expect(result.mcpServers).toEqual({});
+  });
+
+  it('loads a local plugin via relative spec', async () => {
+    const pluginDir = join(projectRoot, 'plugins', 'mine');
+    await mkdir(join(pluginDir, 'skills'), { recursive: true });
+    await writeFile(join(pluginDir, 'plugin.json'), JSON.stringify({ name: 'mine' }));
+
+    const result = await loadPluginBundles({
+      projectRoot,
+      specs: ['./plugins/mine'],
+      autoDiscover: false,
+    });
+
+    expect(result.plugins).toHaveLength(1);
+    expect(result.plugins[0].manifest.name).toBe('mine');
+    expect(result.skillDirs).toEqual([join(pluginDir, 'skills')]);
+  });
+
+  it('auto-discovers bundle directories under .agentuse/plugins', async () => {
+    const pluginDir = join(projectRoot, '.agentuse', 'plugins', 'auto1');
+    await mkdir(pluginDir, { recursive: true });
+    await writeFile(join(pluginDir, 'plugin.json'), JSON.stringify({ name: 'auto1' }));
+
+    const result = await loadPluginBundles({ projectRoot });
+    expect(result.plugins.find(p => p.manifest.name === 'auto1')).toBeTruthy();
+  });
+
+  it('ignores bundle dirs without a plugin.json (legacy single-file plugins)', async () => {
+    const dir = join(projectRoot, '.agentuse', 'plugins', 'legacy-dir');
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, 'something.js'), 'export default {};');
+
+    const result = await loadPluginBundles({ projectRoot });
+    expect(result.plugins).toEqual([]);
+  });
+
+  it('namespaces MCP servers by plugin name', async () => {
+    const pluginDir = join(projectRoot, 'p');
+    await mkdir(pluginDir, { recursive: true });
+    await writeFile(
+      join(pluginDir, 'plugin.json'),
+      JSON.stringify({
+        name: 'p',
+        mcpServers: { mcpServers: { db: { command: 'echo' } } },
+      })
+    );
+
+    const result = await loadPluginBundles({ projectRoot, specs: ['./p'], autoDiscover: false });
+    expect(Object.keys(result.mcpServers)).toEqual(['p.db']);
+  });
+
+  it('does not throw on a bad spec — warns and continues', async () => {
+    const result = await loadPluginBundles({
+      projectRoot,
+      specs: ['not a valid spec/'],
+      autoDiscover: false,
+    });
+    expect(result.plugins).toEqual([]);
+  });
+
+  it('deduplicates the same root resolved twice', async () => {
+    const pluginDir = join(projectRoot, '.agentuse', 'plugins', 'dup');
+    await mkdir(pluginDir, { recursive: true });
+    await writeFile(join(pluginDir, 'plugin.json'), JSON.stringify({ name: 'dup' }));
+
+    const result = await loadPluginBundles({
+      projectRoot,
+      // Auto-discovered AND explicitly listed → must only count once.
+      specs: ['./.agentuse/plugins/dup'],
+    });
+    expect(result.plugins.filter(p => p.manifest.name === 'dup')).toHaveLength(1);
+  });
+});

--- a/tests/plugin-bundle-manifest.test.ts
+++ b/tests/plugin-bundle-manifest.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, writeFile, mkdir, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { findManifest, loadPluginFromRoot, MANIFEST_LOCATIONS } from '../src/plugin-bundle/manifest';
+
+describe('plugin-bundle manifest', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'plugin-manifest-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('finds plugin.json at root', async () => {
+    await writeFile(join(dir, 'plugin.json'), JSON.stringify({ name: 'p1' }));
+    const found = await findManifest(dir);
+    expect(found).toBe(join(dir, 'plugin.json'));
+  });
+
+  it('prefers .plugin/plugin.json over root plugin.json', async () => {
+    await mkdir(join(dir, '.plugin'));
+    await writeFile(join(dir, '.plugin', 'plugin.json'), JSON.stringify({ name: 'inner' }));
+    await writeFile(join(dir, 'plugin.json'), JSON.stringify({ name: 'outer' }));
+    const found = await findManifest(dir);
+    expect(found).toBe(join(dir, '.plugin', 'plugin.json'));
+  });
+
+  it('finds .claude-plugin/plugin.json', async () => {
+    await mkdir(join(dir, '.claude-plugin'));
+    await writeFile(join(dir, '.claude-plugin', 'plugin.json'), JSON.stringify({ name: 'claude' }));
+    const found = await findManifest(dir);
+    expect(found).toBe(join(dir, '.claude-plugin', 'plugin.json'));
+  });
+
+  it('returns null when no manifest exists', async () => {
+    expect(await findManifest(dir)).toBeNull();
+  });
+
+  it('loads a minimal plugin and applies default skill/agent dirs', async () => {
+    await writeFile(join(dir, 'plugin.json'), JSON.stringify({ name: 'minimal' }));
+    await mkdir(join(dir, 'skills'));
+    await mkdir(join(dir, 'agents'));
+    const plugin = await loadPluginFromRoot(dir, 'test');
+    expect(plugin).not.toBeNull();
+    expect(plugin!.manifest.name).toBe('minimal');
+    expect(plugin!.skillDirs).toEqual([join(dir, 'skills')]);
+    expect(plugin!.agentDirs).toEqual([join(dir, 'agents')]);
+    expect(plugin!.mcpServers).toEqual({});
+  });
+
+  it('omits implicit skill/agent dirs when missing', async () => {
+    await writeFile(join(dir, 'plugin.json'), JSON.stringify({ name: 'bare' }));
+    const plugin = await loadPluginFromRoot(dir, 'test');
+    expect(plugin!.skillDirs).toEqual([]);
+    expect(plugin!.agentDirs).toEqual([]);
+  });
+
+  it('honors explicit skills/agents arrays', async () => {
+    await mkdir(join(dir, 'a'));
+    await mkdir(join(dir, 'b'));
+    await mkdir(join(dir, 'extra-agents'));
+    await writeFile(
+      join(dir, 'plugin.json'),
+      JSON.stringify({ name: 'multi', skills: ['a', 'b'], agents: 'extra-agents' })
+    );
+    const plugin = await loadPluginFromRoot(dir, 'test');
+    expect(plugin!.skillDirs).toEqual([join(dir, 'a'), join(dir, 'b')]);
+    expect(plugin!.agentDirs).toEqual([join(dir, 'extra-agents')]);
+  });
+
+  it('loads inline mcpServers and expands ${PLUGIN_ROOT}', async () => {
+    await writeFile(
+      join(dir, 'plugin.json'),
+      JSON.stringify({
+        name: 'mcp-plugin',
+        mcpServers: {
+          mcpServers: {
+            db: { command: '${PLUGIN_ROOT}/bin/server', args: ['--root', '${CLAUDE_PLUGIN_ROOT}'] },
+          },
+        },
+      })
+    );
+    const plugin = await loadPluginFromRoot(dir, 'test');
+    const db = (plugin!.mcpServers as any).db;
+    expect(db.command).toBe(join(dir, 'bin/server'));
+    expect(db.args).toEqual(['--root', dir]);
+  });
+
+  it('loads mcpServers from external file path', async () => {
+    await writeFile(
+      join(dir, '.mcp.json'),
+      JSON.stringify({ mcpServers: { x: { command: '${PLUGIN_ROOT}/x' } } })
+    );
+    await writeFile(
+      join(dir, 'plugin.json'),
+      JSON.stringify({ name: 'with-file', mcpServers: '.mcp.json' })
+    );
+    const plugin = await loadPluginFromRoot(dir, 'test');
+    expect((plugin!.mcpServers as any).x.command).toBe(join(dir, 'x'));
+  });
+
+  it('rejects invalid plugin names', async () => {
+    await writeFile(join(dir, 'plugin.json'), JSON.stringify({ name: 'Bad_Name' }));
+    await expect(loadPluginFromRoot(dir, 'test')).rejects.toThrow(/kebab-case/);
+  });
+
+  it('rejects malformed JSON', async () => {
+    await writeFile(join(dir, 'plugin.json'), '{not json');
+    await expect(loadPluginFromRoot(dir, 'test')).rejects.toThrow(/Invalid JSON/);
+  });
+
+  it('returns null when there is no manifest at the root', async () => {
+    const out = await loadPluginFromRoot(dir, 'test');
+    expect(out).toBeNull();
+  });
+
+  it('exposes manifest locations in priority order', () => {
+    expect(MANIFEST_LOCATIONS[0]).toBe('.plugin/plugin.json');
+  });
+});

--- a/tests/plugin-bundle-spec.test.ts
+++ b/tests/plugin-bundle-spec.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'bun:test';
+import { parsePluginSpec } from '../src/plugin-bundle/spec';
+
+describe('parsePluginSpec', () => {
+  it('parses local relative path', () => {
+    const spec = parsePluginSpec('./plugins/foo');
+    expect(spec.kind).toBe('local');
+    if (spec.kind === 'local') expect(spec.path).toBe('./plugins/foo');
+  });
+
+  it('parses local parent path', () => {
+    const spec = parsePluginSpec('../shared/foo');
+    expect(spec.kind).toBe('local');
+  });
+
+  it('parses absolute path', () => {
+    const spec = parsePluginSpec('/abs/foo');
+    expect(spec.kind).toBe('local');
+  });
+
+  it('parses home-relative path', () => {
+    const spec = parsePluginSpec('~/plugins/foo');
+    expect(spec.kind).toBe('local');
+  });
+
+  it('parses owner/repo shorthand', () => {
+    const spec = parsePluginSpec('agentuse/example');
+    expect(spec.kind).toBe('git');
+    if (spec.kind === 'git') {
+      expect(spec.host).toBe('github');
+      expect(spec.owner).toBe('agentuse');
+      expect(spec.repo).toBe('example');
+      expect(spec.subpath).toBeUndefined();
+      expect(spec.ref).toBeUndefined();
+    }
+  });
+
+  it('parses owner/repo with subpath', () => {
+    const spec = parsePluginSpec('agentuse/example/.github/plugins/my-plugin');
+    expect(spec.kind).toBe('git');
+    if (spec.kind === 'git') {
+      expect(spec.subpath).toBe('.github/plugins/my-plugin');
+      expect(spec.ref).toBeUndefined();
+    }
+  });
+
+  it('parses owner/repo@ref', () => {
+    const spec = parsePluginSpec('agentuse/example@v1.2.3');
+    expect(spec.kind).toBe('git');
+    if (spec.kind === 'git') expect(spec.ref).toBe('v1.2.3');
+  });
+
+  it('parses owner/repo/subpath@ref', () => {
+    const spec = parsePluginSpec('org/repo/sub/dir@main');
+    expect(spec.kind).toBe('git');
+    if (spec.kind === 'git') {
+      expect(spec.subpath).toBe('sub/dir');
+      expect(spec.ref).toBe('main');
+    }
+  });
+
+  it('parses https git URL', () => {
+    const spec = parsePluginSpec('https://github.com/org/repo.git');
+    expect(spec.kind).toBe('git');
+    if (spec.kind === 'git') {
+      expect(spec.host).toBe('generic');
+      expect(spec.owner).toBe('org');
+      expect(spec.repo).toBe('repo');
+      expect(spec.url).toBe('https://github.com/org/repo.git');
+    }
+  });
+
+  it('parses https git URL with ref', () => {
+    const spec = parsePluginSpec('https://github.com/org/repo.git@v1.0.0');
+    expect(spec.kind).toBe('git');
+    if (spec.kind === 'git') {
+      expect(spec.ref).toBe('v1.0.0');
+      expect(spec.url).toBe('https://github.com/org/repo.git');
+    }
+  });
+
+  it('parses ssh git URL without splitting on user@host', () => {
+    const spec = parsePluginSpec('git@github.com:org/repo.git');
+    expect(spec.kind).toBe('git');
+    if (spec.kind === 'git') {
+      expect(spec.owner).toBe('org');
+      expect(spec.repo).toBe('repo');
+      expect(spec.ref).toBeUndefined();
+    }
+  });
+
+  it('parses ssh git URL with ref', () => {
+    const spec = parsePluginSpec('git@github.com:org/repo.git@main');
+    expect(spec.kind).toBe('git');
+    if (spec.kind === 'git') expect(spec.ref).toBe('main');
+  });
+
+  it('throws on empty', () => {
+    expect(() => parsePluginSpec('   ')).toThrow();
+  });
+
+  it('throws on bare token', () => {
+    expect(() => parsePluginSpec('justone')).toThrow();
+  });
+
+  it('throws on invalid characters', () => {
+    expect(() => parsePluginSpec('bad name/repo')).toThrow();
+  });
+});


### PR DESCRIPTION
## Intent

Add a Claude / VS Code-compatible **plugin bundle** system to AgentUse, alongside the existing JS/TS lifecycle-hook plugins.

A plugin bundle is a directory shipping a `plugin.json` manifest plus any combination of skills, agents, and MCP server definitions. Bundles can live locally, be auto-discovered, or be pulled from a Git repository — making them shareable across the AgentUse / Claude Code / VS Code Copilot ecosystems.

## Why

Today, "plugins" in AgentUse mean single JS/TS files with lifecycle event handlers (`agent:complete`, …). There is no way to package skills + MCP servers + agents into a redistributable unit, and no way to consume one from a Git repo. This PR closes that gap with a format that is intentionally interoperable with the Claude Code and VS Code agent-plugin specs (`plugin.json` at root, `.plugin/`, `.claude-plugin/`, or `.github/plugin/`).

## What's in this PR (MVP)

- **New module** `src/plugin-bundle/`
  - `spec.ts` — parser for plugin specs: `./local`, `/abs`, `~/path`, `owner/repo[/sub][@ref]`, `https://…git`, `git@host:…`
  - `manifest.ts` — Zod-validated `plugin.json` loader with multi-format auto-detection and `${PLUGIN_ROOT}` / `${CLAUDE_PLUGIN_ROOT}` token expansion (inline or external `.mcp.json`)
  - `resolver.ts` — shallow `git clone` with idempotent cache under `~/.local/share/agentuse/plugin-cache/<host>/<owner>/<repo>@<ref>/` (SHA fallback when `--branch` fails)
  - `loader.ts` — auto-discovery of bundle directories under `.agentuse/plugins/`, `~/.agentuse/plugins/`, `.claude/plugins/`, `~/.claude/plugins/`, plus resolution of the frontmatter list, with dedup
- **Agent frontmatter** gains an optional `plugins: string[]` field (`src/parser.ts`)
- **Skill discovery** accepts an optional `extraDirs` parameter, threaded through `createSkillTools` → `loadAgentTools` → `prepareAgentExecution` so plugin skills appear alongside project skills
- **MCP wiring** in `src/index.ts`: bundles are resolved before `connectMCP`; their MCP servers are namespaced as `<plugin>.<server>` and merged into the agent config (user config wins on key collisions)
- **Storage**: new `getPluginCacheDir()` helper following the existing XDG convention
- **Tests**: 35 new tests across spec parsing (15), manifest loading (13), and the aggregator (7). All existing parser / skill / lifecycle-plugin / preparation tests still pass.
- **Docs**: `docs/guides/plugins.mdx` reorganized into "Plugin Bundles" + the existing "Programmatic Plugin Mechanism" (lifecycle hooks)

## Example

```yaml
---
model: anthropic:claude-sonnet-4-5
plugins:
  - ./local/path/to/plugin
  - agentuse/example-plugin@v1.2.0
  - agentuse/monorepo/.github/plugins/x
  - https://github.com/org/repo.git
---
```

## Out of scope (follow-ups)

- Shell-style hooks (`hooks.json` with `PreToolUse`, `PostToolUse`, …)
- CLI for managing plugins (`agentuse plugin install/list/remove`)
- Marketplaces (`chat.plugins.marketplaces` equivalent)
- Trust prompt before first execution of a remote plugin
- Lockfile to pin resolved versions
- Auto-loading bundle `agents/` directories into the sub-agent registry (the dirs are collected but not yet consumed by the runner)

## Status

Marked as **draft** because the items above are likely needed before a stable release, and the security/trust story for remote plugins should be agreed on before merging.
